### PR TITLE
seo(A1): config sitemap esplicita (priority 0.7, esclude /tags/**)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -94,6 +94,17 @@ const config: Config = {
                 anonymizeIP: true,
               }
             : undefined,
+        // Sitemap: explicit config (preset-classic enables the plugin by
+        // default with priority 0.5 and no ignorePatterns). We pin priority
+        // to 0.7 to signal these pages as above-average importance, and skip
+        // the auto-generated /tags/** pages to free crawl budget — they
+        // showed up empty / "Crawled - currently not indexed" in GSC.
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.7,
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml',
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
## Summary

Fase **A1** del workplan SEO (`tmp/workplan-seo.md`): rende esplicita la config del sitemap nel preset-classic, alza la `priority` a 0.7 ed esclude le `/tags/**` auto-generate dal sitemap per liberare crawl budget.

- `preset-classic` abilita `@docusaurus/plugin-sitemap` di default ma con `priority: 0.5` e nessun `ignorePatterns`
- Le ~79 tag pages auto-generate sono in larga parte thin content e nel baseline GSC compaiono come "Crawled — currently not indexed" → sprecano crawl budget
- `priority: 0.7` segnala a Google che le pagine vere (ricette, ingredienti, negozi) sono above-average importance

## Verifica build

| Check | Atteso | Ottenuto |
|---|---|---|
| `<loc>` totali nel sitemap | ≥ 170 (acceptance workplan) | **172** ✓ |
| Entries `/tags/**` | 0 | **0** ✓ |
| Priority uniforme | 0.7 | **0.7** ✓ |

Pre-modifica: 251 entries totali (172 utili + 79 tag pages).
Post-modifica: 172 entries (solo le pagine utili).

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa
- [x] `grep -o '<loc>' build/sitemap.xml | wc -l` → 172 ≥ 170
- [x] `grep -oE '<loc>[^<]*tags/[^<]*</loc>' build/sitemap.xml | wc -l` → 0
- [ ] Re-submit `https://paginegiappe.it/sitemap.xml` su GSC dopo merge → "Send sitemap"
- [ ] Monitor a 30gg le pagine "Crawled - currently not indexed" (baseline 14, target ≤ 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)