### PR TITLE
seo(A2): titleDelimiter '·' + title homepage keyword-first

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
-  title: Le ricette giapponesi di Jeko
+  title: "Ricette Giapponesi · 90+ ricette autentiche in italiano"
   sidebar_label: 🏠 Home
-  description: Benvenuti sul mio sito di ricette giapponesi!
+  description: "90+ ricette giapponesi autentiche in italiano, con foto e video: dal ramen al sushi, dai contorni alle salse. Spiegate passo passo da chi le ha imparate dai libri giapponesi."
   pagination_next: null
   pagination_prev: null
   hide_table_of_contents: true

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,6 +7,9 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'Le Ricette Giapponesi di Jeko',
   tagline: 'La Jekucina a casa tua!',
+  // Use a typographic middle dot in <title> tags ("Page · Site") instead of
+  // the default pipe — cleaner on the SERP and the browser tab.
+  titleDelimiter: '·',
   favicon: 'img/favicon.ico',
   trailingSlash: true,
   markdown: {


### PR DESCRIPTION
## Summary

Fase **A2** del workplan SEO (`tmp/workplan-seo.md`): due cambi piccoli ma con impatto SERP diretto.

1. **`titleDelimiter: '·'`** in `docusaurus.config.ts`. Sostituisce il default `|` con il middle dot tipografico. Più pulito sulla SERP e nella browser tab. Si applica a tutto il sito.
2. **Title homepage da "Le ricette giapponesi di Jeko" a "Ricette Giapponesi · 90+ ricette autentiche in italiano"**. La keyword target del progetto (`ricette giapponesi`) sale nei primi caratteri del `<title>` HTML, dove Google la pesa di più. Description aggiornata coerentemente.

## Contesto baseline (dal workplan, sez. 0.1)

> 🚨 La query "ricette giapponesi" non compare nelle 727 query tracciate da GSC → siamo oltre la posizione 100. Stessa cosa per "cucina giapponese", "ricetta giapponese". È il problema più grosso.

A2 da solo non risolve la query target — la home è ancora thin (lo riempiremo in A3) e manca il Recipe schema (A4). Ma con A2 mettiamo la keyword nel posto giusto del `<title>`, è il prerequisito on-page minimo.

## Acceptance del workplan

> Il `<title>` della home contiene esattamente "Ricette Giapponesi" come prime parole.

Verifica sul build statico (`npm run build`):

```
build/index.html:
<title>Ricette Giapponesi · 90+ ricette autentiche in italiano · Le Ricette Giapponesi di Jeko</title>

build/ingredienti/furikake/index.html (esempio non-home, conferma il delimiter):
<title>Furikake: cos'è e come si usa · Le Ricette Giapponesi di Jeko</title>
```

✓ Prime parole = "Ricette Giapponesi"
✓ Delimiter `·` su tutte le pagine

## Note

- Il `<title>` HTML totale della home è ~88 char; Google tronca a ~60. Il troncato mostrerà `Ricette Giapponesi · 90+ ricette autentiche in itali…`, esattamente quello che serve (keyword target + value-add).
- L'H1 visibile sulla home è ora più lungo (3 righe su mobile). Verrà ribilanciato in A3 quando la home si trasformerà da pagina thin a hub con sezioni e DocCardGrid.

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa
- [x] `<title>` home/pagina ingrediente verificato sul build statico
- [x] Verifica live in dev server (preview) dopo restart (titleDelimiter non e' HMR)
- [ ] Re-submit sitemap su GSC dopo merge → forza re-crawl della home

🤖 Generated with [Claude Code](https://claude.com/claude-code)