### PR TITLE
seo(A3): home come hub + nuovo /ricette/preparazioni_di_base/

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,22 +8,71 @@
   sidebar_position: 0
 ---
 import '../src/css/homepage.css';
+import DocCardGrid from '@site/src/components/DocCardGrid';
 
-Benvenuti sul mio sito di ricette giapponesi!
-Questi sono i risultati dei miei studi e delle mie sperimentazioni nella cucina giapponese, e sono in costante cambiamento ed evoluzione. Ogni suggerimento è più che ben accetto.
+export const CATEGORIES = [
+  { id: 'ricette/agemono/kara-age',                       title: '🍤 Agemono',          description: 'Fritti giapponesi: tempura, kara-age, korokke',       permalink: '/ricette/agemono/' },
+  { id: 'ricette/antipasti/hiyashi_nasu',                 title: '🍽️ Antipasti',         description: "Piatti d'apertura e stuzzichini da izakaya",         permalink: '/ricette/antipasti/' },
+  { id: 'ricette/fish/teriyaki_salmon',                   title: '🐟 Pesce',             description: 'Salmone, pesce alla griglia, sashimi e altri secondi',permalink: '/ricette/fish/' },
+  { id: 'ricette/menrui/yakisoba',                        title: '🍜 Menrui',            description: 'Noodles giapponesi: udon, soba, somen, ramen',        permalink: '/ricette/menrui/' },
+  { id: 'ricette/nimono/nikujaga',                        title: '🍲 Nimono',            description: 'Stufati e brasati a fuoco lento',                     permalink: '/ricette/nimono/' },
+  { id: 'ricette/riso/gyudon',                            title: '🍚 Riso',              description: 'Onigiri, donburi, takikomi gohan e gohan mono',       permalink: '/ricette/riso/' },
+  { id: 'ricette/sides/bieta_gialla_ohitashi',            title: '🥗 Contorni',          description: 'Verdure, insalate e piccoli piatti di accompagnamento', permalink: '/ricette/sides/' },
+  { id: 'ricette/tsukemono/daikon_shiokombuzuke',         title: '🥒 Tsukemono',         description: 'Marinati e fermentati alla giapponese',               permalink: '/ricette/tsukemono/' },
+  { id: 'ricette/yakimono/gyoza',                         title: '🍖 Yakimono',          description: 'Cotture alla griglia, in padella e in piastra',       permalink: '/ricette/yakimono/' },
+  { id: 'ricette/zuppe/misoshiru',                        title: '🍲 Zuppe',             description: 'Misoshiru, suimono e zuppe stagionali',               permalink: '/ricette/zuppe/' },
+  { id: 'ricette/preparazioni_di_base/brodi/dashi',       title: '👨🏻‍🍳 Preparazioni di base', description: 'Brodi, salse, condimenti e tecniche di sushi',        permalink: '/ricette/preparazioni_di_base/' },
+];
 
-<div className="paypal-container">
-  <div className="paypal-icon">☕</div>
-  <div className="paypal-content">
-    <h3>Offrimi un caffè</h3>
-    <p>Se il sito ti è stato utile e ti va di supportarmi, puoi offrirmi un caffè — grazie! Il sito è e resterà gratuito. <strong>@amicojeko</strong></p>
-  </div>
-  <a
-    className="paypal-cta"
-    href="https://paypal.me/jeko23"
-    target="_blank"
-    rel="noopener noreferrer"
-  >Supporta con PayPal →</a>
+export const FEATURED_RECIPES = [
+  { id: 'ricette/agemono/kara-age',                       title: 'Kara-Age',         description: 'Pollo fritto giapponese, croccante fuori e succoso dentro', permalink: '/ricette/kara-age/' },
+  { id: 'ricette/yakimono/gyoza',                         title: 'Gyoza',            description: 'Ravioli giapponesi alla piastra',                           permalink: '/ricette/gyoza/' },
+  { id: 'ricette/preparazioni_di_base/brodi/dashi',       title: 'Dashi',            description: 'Il brodo madre della cucina giapponese',                    permalink: '/ricette/dashi/' },
+  { id: 'ricette/preparazioni_di_base/brodi/mentsuyu',    title: 'Mentsuyu',         description: 'Salsa concentrata per soba e udon',                         permalink: '/ricette/mentsuyu/' },
+  { id: 'ricette/fish/teriyaki_salmon',                   title: 'Salmone Teriyaki', description: 'Salmone glassato in salsa teriyaki',                        permalink: '/ricette/salmone_teriyaki/' },
+  { id: 'ricette/riso/onigiri',                           title: 'Onigiri',          description: 'Polpette di riso giapponesi',                               permalink: '/ricette/onigiri/' },
+  { id: 'ricette/riso/gyudon',                            title: 'Gyudon',           description: 'Donburi di manzo e cipolla',                                permalink: '/ricette/gyudon/' },
+  { id: 'ricette/preparazioni_di_base/salse/teriyaki',    title: 'Salsa Teriyaki',   description: 'La salsa teriyaki classica fatta in casa',                  permalink: '/ricette/salsa_teriyaki/' },
+  { id: 'ricette/preparazioni_di_base/salse/ponzu',       title: 'Salsa Ponzu',      description: 'Salsa di soia e agrumi, fresca e versatile',                permalink: '/ricette/salsa_ponzu/' },
+  { id: 'ricette/yakimono/takoyaki',                      title: 'Takoyaki',         description: 'Polpettine di polpo dello street food di Osaka',            permalink: '/ricette/takoyaki/' },
+];
+
+export const KEY_INGREDIENTS = [
+  { id: 'ingredienti/rice',                                title: 'Riso',         description: 'La base assoluta della cucina giapponese',     permalink: '/ingredienti/rice/' },
+  { id: 'ingredienti/miso',                                title: 'Miso',         description: 'Pasta di soia fermentata, tipi e usi',         permalink: '/ingredienti/miso/' },
+  { id: 'ricette/preparazioni_di_base/brodi/dashi',        title: 'Dashi',        description: 'Il brodo madre con kombu e katsuobushi',       permalink: '/ricette/dashi/' },
+  { id: 'ingredienti/katsuobushi',                         title: 'Katsuobushi',  description: 'Scaglie di tonnetto essiccato, anima del dashi', permalink: '/ingredienti/katsuobushi/' },
+  { id: 'ingredienti/nori',                                title: 'Alga Nori',    description: "L'alga in fogli per onigiri e sushi",         permalink: '/ingredienti/nori/' },
+  { id: 'ingredienti/kombu',                               title: 'Alga Kombu',   description: 'Alga essenziale per dashi e brodi',            permalink: '/ingredienti/kombu/' },
+  { id: 'ingredienti/sesamo',                              title: 'Sesamo',       description: 'Semi e olio: aroma in tutto il menu',          permalink: '/ingredienti/sesamo/' },
+  { id: 'ingredienti/shiitake',                            title: 'Shiitake',     description: 'Il fungo umami della cucina giapponese',       permalink: '/ingredienti/shiitake/' },
+];
+
+Questa è la mia raccolta di **ricette giapponesi**, frutto di anni di studio su libri, confronti con maestri straordinari e prove infinite ai fornelli. Ogni piatto è stato testato, rifatto e perfezionato da me, con l'idea di rendere la **cucina giapponese** autentica semplice e accessibile a tutti. Dalle basi fondamentali come [dashi](/ricette/dashi/) e salse, fino ad agemono, menrui, nimono, tsukemono, yakimono e piatti di riso.
+
+Qui trovi cucina casalinga e da izakaya, niente fusion e niente piatti da all you can eat. In più trovi guide su ingredienti e strumenti, le mie [fonti di ispirazione](/libri/) e una lista collaborativa di [negozi giapponesi in Italia](/negozi_orientali/), in continua evoluzione.
+
+## 🍱 Le categorie
+
+<DocCardGrid docs={CATEGORIES} />
+
+## 🔥 Ricette più cercate
+
+<DocCardGrid docs={FEATURED_RECIPES} />
+
+## 🍅 Ingredienti chiave della cucina giapponese
+
+<DocCardGrid docs={KEY_INGREDIENTS} />
+
+## 🏪 Trova ingredienti vicino a te
+
+Cucinare giapponese a casa parte dalla materia prima. Per riso giapponese, miso, mirin, alghe, salsa di soia di qualità e tutto il resto serve un buon **negozio asiatico**. Su [paginegiappe.it/negozi_orientali](/negozi_orientali/) tengo una lista collaborativa di **negozi giapponesi e asiatici in Italia**, regione per regione, con [mappa interattiva](/negozi_orientali/mappa/) e [shop online](/negozi_orientali/online/).
+
+Regioni con più negozi: [Lombardia](/negozi_orientali/lombardia/) · [Lazio](/negozi_orientali/lazio/) · [Piemonte](/negozi_orientali/piemonte/) · [Emilia-Romagna](/negozi_orientali/emilia_romagna/) · [Veneto](/negozi_orientali/veneto/) · [tutte le regioni →](/negozi_orientali/)
+
+<div className="paypal-mini">
+  <span className="paypal-mini-icon">☕</span>
+  <span className="paypal-mini-text">Se il sito ti è utile, <a href="https://paypal.me/jeko23" target="_blank" rel="noopener noreferrer">offrimi un caffè su PayPal</a> — grazie!</span>
 </div>
 
 <div className="social-container">
@@ -37,7 +86,7 @@ Questi sono i risultati dei miei studi e delle mie sperimentazioni nella cucina 
     <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/tiktok.svg" alt="TikTok" width={36} className="social-icon" />
   </a>
 
-  <a href="https://chatgpt.com/g/g-6820cb0fed508191adafb39249db35f0-jeko-s-japanese-recipes-assistant/" target="_blank" rel="noopener noreferrer" title="Jeko’s GPT">
+  <a href="https://chatgpt.com/g/g-6820cb0fed508191adafb39249db35f0-jeko-s-japanese-recipes-assistant/" target="_blank" rel="noopener noreferrer" title="Jeko's GPT">
     <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/openai.svg" alt="ChatGPT" width={36} className="social-icon" />
   </a>
 </div>

--- a/docs/ricette/preparazioni_di_base/brodi/index.md
+++ b/docs/ricette/preparazioni_di_base/brodi/index.md
@@ -2,6 +2,7 @@
 title: "🍲 Brodi"
 description: "Ricette di brodi giapponesi"
 slug: "/ricette/preparazioni_di_base/brodi"
+image: /img/ricette/dashi.jpg
 ---
 import CategoryIndexPage from '@site/src/components/CategoryIndexPage';
 

--- a/docs/ricette/preparazioni_di_base/condimenti/index.md
+++ b/docs/ricette/preparazioni_di_base/condimenti/index.md
@@ -2,6 +2,7 @@
 title: "🧂 Condimenti"
 description: "Condimenti giapponesi di base"
 slug: "/ricette/preparazioni_di_base/condimenti"
+image: /img/ricette/furikake.jpg
 ---
 import CategoryIndexPage from '@site/src/components/CategoryIndexPage';
 

--- a/docs/ricette/preparazioni_di_base/index.md
+++ b/docs/ricette/preparazioni_di_base/index.md
@@ -1,0 +1,36 @@
+---
+title: "👨🏻‍🍳 Preparazioni di base della cucina giapponese"
+description: "Le preparazioni di base della cucina giapponese: dashi e brodi, salse (teriyaki, ponzu, tentsuyu, mentsuyu), condimenti tradizionali e tecniche di sushi e sashimi."
+slug: "/ricette/preparazioni_di_base"
+image: /img/ricette/dashi.jpg
+---
+import DocCardGrid from '@site/src/components/DocCardGrid';
+
+Le **preparazioni di base** sono il cuore della cucina giapponese: senza un buon **dashi** non c'è zuppa di miso, senza una salsa **teriyaki** o **ponzu** mezzo menu sparisce, e senza saper trattare il riso da sushi non si va da nessuna parte. Su queste pagine raccolgo brodi, salse, condimenti e tecniche di sushi e sashimi che si ripetono in mille piatti — gli ingredienti del giapponese di casa.
+
+<DocCardGrid docs={[
+  {
+    id: 'ricette/preparazioni_di_base/brodi/index',
+    title: '🍲 Brodi',
+    description: 'Dashi, mentsuyu, brodi base per ramen e zuppe',
+    permalink: '/ricette/preparazioni_di_base/brodi/',
+  },
+  {
+    id: 'ricette/preparazioni_di_base/salse/index',
+    title: '🧉 Salse',
+    description: 'Teriyaki, ponzu, tentsuyu, tonkatsu, yakitori',
+    permalink: '/ricette/preparazioni_di_base/salse/',
+  },
+  {
+    id: 'ricette/preparazioni_di_base/condimenti/index',
+    title: '🧂 Condimenti',
+    description: 'Furikake e altri condimenti tradizionali',
+    permalink: '/ricette/preparazioni_di_base/condimenti/',
+  },
+  {
+    id: 'ricette/preparazioni_di_base/sushi_and_sashimi/index',
+    title: '🍣 Sushi e sashimi',
+    description: 'Riso da sushi, nigiri, maki e sashimi base',
+    permalink: '/ricette/preparazioni_di_base/sushi_and_sashimi/',
+  },
+]} />

--- a/docs/ricette/preparazioni_di_base/salse/index.md
+++ b/docs/ricette/preparazioni_di_base/salse/index.md
@@ -2,6 +2,7 @@
 title: "🧉 Salse"
 description: "Salse giapponesi di base"
 slug: "/ricette/preparazioni_di_base/salse"
+image: /img/ricette/pollo_teriyaki.jpg
 ---
 import CategoryIndexPage from '@site/src/components/CategoryIndexPage';
 

--- a/src/css/homepage.css
+++ b/src/css/homepage.css
@@ -95,6 +95,46 @@ a.paypal-cta:hover,
   .paypal-content p { margin: 0 auto; }
 }
 
+.paypal-mini {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin: 3rem auto 1.25rem;
+  padding: 0.75rem 1rem;
+  font-family: var(--pg-font-sans);
+  font-size: 0.95rem;
+  color: var(--pg-ink);
+  background: var(--pg-paper-2);
+  border-top: 1px solid var(--pg-rule-soft);
+  border-bottom: 1px solid var(--pg-rule-soft);
+  text-align: center;
+  flex-wrap: wrap;
+}
+
+.paypal-mini-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.paypal-mini-text {
+  line-height: 1.4;
+}
+
+.paypal-mini a,
+.markdown .paypal-mini a {
+  color: var(--pg-red);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.paypal-mini a:hover,
+.markdown .paypal-mini a:hover {
+  color: var(--pg-red-ink);
+  text-decoration: underline;
+}
+
 .social-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Fase **A3** del workplan SEO (`tmp/workplan-seo.md`): trasforma la homepage da pagina thin (poche frasi + PayPal grande) in un vero **hub keyword-rich** con 4 sezioni di card e ~50 link interni. Aggiunge anche `/ricette/preparazioni_di_base/` come nuovo hub di sotto-categorie (brodi, salse, condimenti, sushi).

## Cosa cambia

### Homepage (`docs/index.md`)

Riscritta da capo, mantenendo title/desc da A2 e PayPal/social. Nuova struttura:

1. **Intro** (testo fornito dal proprietario, 2 paragrafi keyword-rich con "ricette giapponesi" / "cucina giapponese" / link a libri e negozi)
2. **🍱 Le categorie** — 11 card (10 top-level + nuovo hub Preparazioni di base)
3. **🔥 Ricette più cercate** — 10 card curate: kara-age, gyoza, dashi, mentsuyu, salmone teriyaki, onigiri, gyudon, salsa teriyaki, salsa ponzu, takoyaki
4. **🍅 Ingredienti chiave** — 8 card: riso, miso, dashi, katsuobushi, alga nori, alga kombu, sesamo, shiitake
5. **🏪 Trova ingredienti vicino a te** — intro + 5 regioni top come lista inline + link a mappa/online
6. **PayPal mini-callout** + social (PayPal "visibile ma non preponderante" come da feedback)

Le 3 liste curate (categorie/ricette/ingredienti) sono **hardcoded inline** in cima al file via `export const`, facili da modificare senza toccare nessun altro file.

**Trick tecnico:** le card categoria usano `id` di una ricetta rappresentativa (per l'immagine via `image-metadata.json`) ma `permalink` della categoria — così evitiamo di toccare i 10 sub-cat index page.

### Nuovo `/ricette/preparazioni_di_base/`

`docs/ricette/preparazioni_di_base/index.md` (file nuovo). Hub con intro + 4 card a Brodi/Salse/Condimenti/Sushi e sashimi. Preparazioni_di_base ora è una pagina indicizzabile, slug `/ricette/preparazioni_di_base/`. Aggiunto `image:` ai 3 sub-cat con foto disponibile (brodi → dashi.jpg, condimenti → furikake.jpg, salse → pollo_teriyaki.jpg). Sushi_and_sashimi resta col placeholder finché non ci sono foto adatte (task separato).

### CSS

Nuova classe `.paypal-mini` in `src/css/homepage.css` per il callout PayPal compatto (icona ☕ + 1 frase + link). Il vecchio `.paypal-container` resta nel CSS (non più usato sulla home, eventualmente usabile altrove).

## Acceptance del workplan A3

| Check | Target | Risultato |
|---|---|---|
| Link interni nel body | ≥ 30 | **48** ✓ |
| Parole utili (escluso boilerplate) | > 600 | **469** ⚠️ |

Le 469 parole sono sotto il target di 600: la copy proposta dal proprietario è compatta per scelta. Espandibile in iter futura (es. quando in Fase D si aggiunge la FAQ) senza finire in filler. Il valore strategico della home (hub-page con 48 link e 4 sezioni semantiche) è già acquisito.

## Note tecniche emerse durante il dev

- **MDX `\'` escape rotto in micromark**: gli apostrofi escapati in `export const` MDX expression facevano fallire acorn (`Could not parse expression`). Fix: doppie virgolette nelle stringhe con apostrofo (`"Piatti d'apertura..."`).
- **Sushi_and_sashimi senza foto**: l'unica sub-cat di prep_base che mostra il placeholder. Non bloccante per A3.
- **Region cards**: inizialmente avevo proposto 5 card region nella sezione negozi, ma le pagine region non hanno foto → tutte mostravano il placeholder, brutto. Convertite in lista inline `[Lombardia](…) · [Lazio](…) · …`.
- **Link a `/ingredienti/` e `/strumenti/`** rimossi dall'intro: non esistono come pagina indice. Da fixare in fase futura del workplan creando le rispettive index.

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa, broken-link check pulito
- [x] Verifica preview dev: H1 corretto, 4 H2 ordinate, 30 card renderizzate (11+10+8+1 wrapper), PayPal mini visibile, social row, immagini caricate per tutte le card categorie
- [ ] Re-submit sitemap su GSC dopo merge → forza re-crawl della home + nuovo `/ricette/preparazioni_di_base/`
- [ ] Monitor a 30gg engagement home (baseline 9s) — target 25s da Fase A3

🤖 Generated with [Claude Code](https://claude.com/claude-code)