### PR TITLE
seo(A4): Recipe JSON-LD schema su /ricette/* (PoC dashi+kara-age)

### DIFF
--- a/docs/ricette/agemono/kara-age.md
+++ b/docs/ricette/agemono/kara-age.md
@@ -39,7 +39,7 @@ tags:
 - Shichimi togarashi
 - oppure una fettina di limone da spremere sopra
 
-## Preprarazione
+## Preparazione
 
 Tagliare il pollo in cubetti di circa 4 centimetri di lato, l'importante è che siano tutti più o meno delle stesse dimensioni, così che si cuociano uniformemente, meglio pezzi un po' piu cicciottelli che restano piu' umidi e danno piu' gusto.
 

--- a/docs/ricette/antipasti/chawanmushi.md
+++ b/docs/ricette/antipasti/chawanmushi.md
@@ -6,30 +6,30 @@ description: Budino di uova cotto al vapore
 slug: /ricette/chawanmushi
 image: /img/ricette/chawanmushi.jpg
 ingredients:
-- dashi
-- mirin
-- sake
-- sale
-- salsa di soia
-- uovo
-- ginnan
-- edamame
-- shiitake
-- gamberi
-- prezzemolo
-- cipolline
+  - dashi
+  - mirin
+  - sake
+  - sale
+  - salsa di soia
+  - uovo
+  - ginnan
+  - edamame
+  - shiitake
+  - gamberi
+  - prezzemolo
+  - cipolline
 tags:
-- ginnan
-- mirin
-- sake
-- shiitake
+  - ginnan
+  - mirin
+  - sake
+  - shiitake
+recipeYield: 4 persone
 ---
 Il Chawanmushi (茶碗蒸し) è un budino di uova salato cotto al vapore, tipico della cucina giapponese. La parola "chawan" significa "ciotola" e "mushi" significa "cotto al vapore". È un piatto delicato e saporito, spesso servito come antipasto o contorno in un pasto giapponese.
 
 <ImageComponent />
 
-## Ingredienti per 4 persone
-
+## Ingredienti
 - 120 ml di uovo, io uso 3 rossi e bianchi q.b. per arrivare a 120 ml
 - 360 ml di [dashi](/ricette/dashi) (rapporto di 3:1 con le uova)
 - 30 ml di salsa di soia (meglio se chiara)

--- a/docs/ricette/menrui/natto_soba.md
+++ b/docs/ricette/menrui/natto_soba.md
@@ -2,25 +2,28 @@
 title: Natto Soba
 sidebar_custom_props:
   subtitle: Soba freddi con natto
-description: Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie
+description: >-
+  Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre
+  delizie
 slug: /ricette/natto_soba
 image: /img/ricette/natto_soba.jpg
 ingredients:
-- Cipolline verdi o negi
-- Kizami nori
-- natto
-- katsuobushi
-- soba
-- uovo
+  - Cipolline verdi o negi
+  - Kizami nori
+  - natto
+  - katsuobushi
+  - soba
+  - uovo
 tags:
-- katsuobushi
-- kizami_nori
-- natto
-- negi
-- nori
-- soba
+  - katsuobushi
+  - kizami_nori
+  - natto
+  - negi
+  - nori
+  - soba
+recipeYield: 2 persone
 ---
-## Ingredienti per 2 persone
+## Ingredienti
 - 200g di [soba](/ingredienti/soba)
 - Cipolline verdi o [negi](/ingredienti/negi)
 - 1 confezione di [natto](/ingredienti/natto)

--- a/docs/ricette/menrui/natto_soba.md
+++ b/docs/ricette/menrui/natto_soba.md
@@ -2,9 +2,7 @@
 title: Natto Soba
 sidebar_custom_props:
   subtitle: Soba freddi con natto
-description: >-
-  Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre
-  delizie
+description: "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie"
 slug: /ricette/natto_soba
 image: /img/ricette/natto_soba.jpg
 ingredients:

--- a/docs/ricette/menrui/tori_dashi_no_nyumen.md
+++ b/docs/ricette/menrui/tori_dashi_no_nyumen.md
@@ -1,24 +1,26 @@
 ---
 title: Tori dashi no nyūmen
-description: Somen in brodo di pollo caldo, la versione confortante e super economica di un classico giapponese
+description: >-
+  Somen in brodo di pollo caldo, la versione confortante e super economica di un
+  classico giapponese
 slug: /ricette/tori_dashi_no_nyumen
 sidebar_custom_props:
-  subtitle: "Somen in brodo di pollo caldo"
+  subtitle: Somen in brodo di pollo caldo
 image: /img/ricette/tori-dashi-nyumen.jpg
 ingredients:
-- ossa di pollo
-- zenzero
-- porro
-- salsa di soia
-- somen
-- cipollotto
+  - ossa di pollo
+  - zenzero
+  - porro
+  - salsa di soia
+  - somen
+  - cipollotto
+recipeYield: 2 persone
 ---
 In Giappone, i somen sono famosi soprattutto nella loro versione estiva, serviti freddi. Tuttavia, quando si cerca un pasto caldo e ristoratore, la scelta ricade sul **Nyūmen** (煮麺). Il termine si riferisce alla versione calda di questi sottili spaghetti di frumento e deriva originariamente da *nimeno*, che significa letteralmente "tagliolini bolliti". Questa ricetta del Tori dashi no nyūmen trasforma degli scarti di macelleria in un brodo umami profondo, creando un pasto completo che costa pochissimo ma regala una soddisfazione degna dei migliori ramen bar.
 
 <ImageComponent />
 
-## Ingredienti per 2 persone
-
+## Ingredienti
 - Ossa di pollo (circa 300-400g, come ali o carcasse)
 - 3 litri d'acqua (divisi in due fasi)
 - Un pezzetto di [zenzero](/tags/zenzero) fresco

--- a/docs/ricette/menrui/tori_dashi_no_nyumen.md
+++ b/docs/ricette/menrui/tori_dashi_no_nyumen.md
@@ -1,8 +1,6 @@
 ---
 title: Tori dashi no nyūmen
-description: >-
-  Somen in brodo di pollo caldo, la versione confortante e super economica di un
-  classico giapponese
+description: "Somen in brodo di pollo caldo, la versione confortante e super economica di un classico giapponese"
 slug: /ricette/tori_dashi_no_nyumen
 sidebar_custom_props:
   subtitle: Somen in brodo di pollo caldo

--- a/docs/ricette/menrui/zaru_soba.md
+++ b/docs/ricette/menrui/zaru_soba.md
@@ -4,19 +4,20 @@ description: Spaghetti di grano saraceno freddi
 slug: /ricette/zaru_soba
 image: /img/ricette/zaru_soba.jpg
 sidebar_custom_props:
-  subtitle: "Soba freddi da intingere nel mentsuyu"
+  subtitle: Soba freddi da intingere nel mentsuyu
 ingredients:
-- spaghetti di grano saraceno
-- mentsuyu
-- kizami nori
-- cipolline verdi
-- wasabi
-- daikon
-- zenzero
+  - spaghetti di grano saraceno
+  - mentsuyu
+  - kizami nori
+  - cipolline verdi
+  - wasabi
+  - daikon
+  - zenzero
 tags:
-- daikon
-- kizami_nori
-- nori
+  - daikon
+  - kizami_nori
+  - nori
+recipeYield: 2 persone
 ---
 Gli zaru soba sono spaghetti di grano saraceno freddi, serviti con una salsa a base di [(mentsuyu)](/ricette/mentsuyu). Sono un piatto estivo molto popolare, e si trovano in molti ristoranti giapponesi. Sono molto semplici da preparare, e sono un ottimo piatto per l'estate.
 
@@ -24,8 +25,7 @@ Cercate di trovare degli spaghetti di grano saraceno di buona qualita', con la p
 
 <ImageComponent />
 
-## Ingredienti per 2 persone
-
+## Ingredienti
 - 200g di spaghetti di grano saraceno
 
 ### Per la salsa:

--- a/docs/ricette/nimono/kakuni.md
+++ b/docs/ricette/nimono/kakuni.md
@@ -45,7 +45,7 @@ Per 4 persone:
 - 4 fette di [daikon](/ingredienti/daikon)
 - 4 bok choy o equivalente in peso di spinaci
 
-## Preparazione (metodo veloce)
+## Preparazione
 
 Prima di tutto una premessa: questo è il metodo "veloce" per la preparazione del buta kaku-ni. Secondo il metodo tradizionale, spiegato ottimamente da Shizuo Tsuji nel suo libro "Japanese Cooking: A Simple Art" (praticamente la bibbia della cucina giapponese), ci vogliono due giorni per preparare il kakuni. Giuro che un giorno ci proverò, ma per ora mi accontento di questa versione.
 

--- a/docs/ricette/nimono/nikujaga.md
+++ b/docs/ricette/nimono/nikujaga.md
@@ -2,9 +2,7 @@
 title: Nikujaga
 sidebar_custom_props:
   subtitle: Stufato di carne e patate
-description: >-
-  Carne e patate, il comfort food per eccellenza della cucina casalinga
-  giapponese
+description: "Carne e patate, il comfort food per eccellenza della cucina casalinga giapponese"
 slug: /ricette/nikujaga
 image: /img/ricette/nikujaga.jpg
 ingredients:

--- a/docs/ricette/nimono/nikujaga.md
+++ b/docs/ricette/nimono/nikujaga.md
@@ -2,26 +2,28 @@
 title: Nikujaga
 sidebar_custom_props:
   subtitle: Stufato di carne e patate
-description: Carne e patate, il comfort food per eccellenza della cucina casalinga giapponese
+description: >-
+  Carne e patate, il comfort food per eccellenza della cucina casalinga
+  giapponese
 slug: /ricette/nikujaga
 image: /img/ricette/nikujaga.jpg
 ingredients:
-- manzo
-- patate
-- carote
-- cipolle
-- dashi
-- mirin
-- salsa di soia
+  - manzo
+  - patate
+  - carote
+  - cipolle
+  - dashi
+  - mirin
+  - salsa di soia
 tags:
-- mirin
+  - mirin
+recipeYield: 4 persone
 ---
 Spesso abbiamo un'idea limitata della cucina giapponese, associandola quasi esclusivamente a sushi o ramen. Il Nikujaga (letteralmente "carne e patate") è invece la quintessenza della cucina casalinga nipponica: un piatto estremamente comune, semplice ed economico. Si tratta di uno stufato dolce e salato che scalda il cuore, perfetto per una cena in famiglia, che piace a tutti, grandi e piccini.
 
 <ImageComponent />
 
-## Ingredienti per 4 persone
-
+## Ingredienti
 - 300g di manzo (taglio sottile o straccetti)
 - 2 patate grandi
 - 1 carota grande

--- a/docs/ricette/preparazioni_di_base/brodi/vegan_dashi.md
+++ b/docs/ricette/preparazioni_di_base/brodi/vegan_dashi.md
@@ -2,9 +2,7 @@
 title: Dashi Vegano
 sidebar_custom_props:
   subtitle: Brodo vegetale giapponese
-description: >-
-  La base fondamentale della cucina giapponese in versione vegana. Un brodo
-  ricco di umami preparato con alga kombu e funghi shiitake.
+description: "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake."
 slug: /ricette/dashi_vegan
 ingredients:
   - Alga Kombu

--- a/docs/ricette/preparazioni_di_base/brodi/vegan_dashi.md
+++ b/docs/ricette/preparazioni_di_base/brodi/vegan_dashi.md
@@ -2,17 +2,20 @@
 title: Dashi Vegano
 sidebar_custom_props:
   subtitle: Brodo vegetale giapponese
-description: La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.
+description: >-
+  La base fondamentale della cucina giapponese in versione vegana. Un brodo
+  ricco di umami preparato con alga kombu e funghi shiitake.
 slug: /ricette/dashi_vegan
 ingredients:
-- Alga Kombu
-- Funghi Shiitake
-- Acqua
+  - Alga Kombu
+  - Funghi Shiitake
+  - Acqua
 tags:
-- dashi
-- vegan
-- kombu
-- shiitake
+  - dashi
+  - vegan
+  - kombu
+  - shiitake
+recipeYield: circa 2 litri
 ---
 Il **Dashi Vegano** (o *Shojin Dashi*, dal nome della cucina devozionale buddhista) è una base fondamentale per chi vuole seguire una dieta vegetariana o vegana senza rinunciare ai sapori autentici del Giappone.
 Il [Dashi](/ricette/dashi) è il brodo onnipresente nella cucina giapponese: lo troviamo nelle zuppe, nei minestroni, negli stufati e anche nelle salse.
@@ -20,8 +23,7 @@ Il Giappone vanta una tradizione pluricentenaria di cucina vegana che proviene d
 
 L'ingrediente chiave è l'[Alga Kombu](/ingredienti/kombu), che va scelta di ottima qualità perché incide molto sul sapore finale, abbinata ai [Funghi Shiitake](/ingredienti/shiitake) disidratati.
 
-## Ingredienti (per circa 2 litri di brodo)
-
+## Ingredienti
 - 2 litri di Acqua
 - 20-30g di [Alga Kombu](/ingredienti/kombu)
 - 5 [Funghi Shiitake](/ingredienti/shiitake) disidratati (secchi)

--- a/docs/ricette/riso/gyudon.md
+++ b/docs/ricette/riso/gyudon.md
@@ -6,27 +6,27 @@ description: La ciotola di riso con carne di manzo e cipolla
 slug: /ricette/gyudon
 image: /img/ricette/gyudon.jpg
 ingredients:
-- Beni shoga
-- cipolla
-- cipollina verde
-- dashi
-- manzo
-- mirin
-- riso bianco
-- sake
-- salsa di soia
+  - Beni shoga
+  - cipolla
+  - cipollina verde
+  - dashi
+  - manzo
+  - mirin
+  - riso bianco
+  - sake
+  - salsa di soia
 tags:
-- beni_shoga
-- mirin
-- rice
-- sake
+  - beni_shoga
+  - mirin
+  - rice
+  - sake
+recipeYield: 2 persone
 ---
 Il gyudon e' un piatto molto popolare in Giappone, e' una ciotola di riso con carne di manzo e cipolla. E' molto semplice da preparare e molto gustoso, ed ha fatto la fortuna di una delle catene di ristoranti piu' famose in Giappone, il Yoshinoya.
 
 <ImageComponent />
 
-## Ingredienti per 2 persone
-
+## Ingredienti
 - riso bianco
 - 300 g di manzo, io uso il cappello del prete tagliato a macchina, e' meglio usare un taglio molto grasso
 - 1/2 cipolla gialla

--- a/docs/ricette/riso/hamburger_don.md
+++ b/docs/ricette/riso/hamburger_don.md
@@ -6,25 +6,25 @@ description: Una ciotola di riso (donburi) facile e veloce con carne macinata e 
 slug: /ricette/hamburger-donburi
 image: /img/ricette/hamburger_don.jpg
 ingredients:
-- Riso
-- Carne macinata
-- Uova
-- Cipolla
-- Ketchup
-- Salsa Worcestershire
-- Salsa Tonkatsu
-- Olio di semi
-- Sale
-- Pepe
+  - Riso
+  - Carne macinata
+  - Uova
+  - Cipolla
+  - Ketchup
+  - Salsa Worcestershire
+  - Salsa Tonkatsu
+  - Olio di semi
+  - Sale
+  - Pepe
 tags:
-- rice
+  - rice
+recipeYield: 1 persona
 ---
 In giappone esiste un tipo di cucina ispirato alla cucina occidentale chiamato Yoshoku (洋食), che letteralmente significa "cibo occidentale". Si tratta di piatti che sono stati adattati ai gusti giapponesi, spesso con ingredienti locali e tecniche di cottura giapponesi. Questo piatto, chiamato Hamburger Don (ハンバーグ丼), è un esempio perfetto di Yoshoku. Ed e' una mezza svolta per quando volete fare una cosa al volo, buona e sostanziosa.
 
 <ImageComponent />
 
-## Ingredienti (Per 1 persona)
-
+## Ingredienti
 - Una ciotola di [Riso](/ingredienti/rice) caldo
 - 150g di Carne macinata a piacere (manzo, maiale o mista)
 - 1 Uovo

--- a/docs/ricette/riso/onigiri.md
+++ b/docs/ricette/riso/onigiri.md
@@ -5,21 +5,21 @@ sidebar_custom_props:
 description: Il classico snack giapponese per una merenda veloce o un pranzo al sacco.
 slug: /ricette/onigiri
 ingredients:
-- riso cotto
-- tonno sott'olio
-- maionese
-- alga nori
-- sale
+  - riso cotto
+  - tonno sott'olio
+  - maionese
+  - alga nori
+  - sale
 tags:
-- nori
-- rice
+  - nori
+  - rice
+recipeYield: 2 onigiri
 ---
 Gli onigiri (おにぎり), o _omusubi_, sono uno degli snack giapponesi più iconici e amati. Sono delle "polpette" di [riso](/ingredienti/rice) bianco, generalmente a forma triangolare, a forma di polpetta o cilindrica, che spesso racchiudono un ripieno e sono avvolte in una striscia di [alga nori](/ingredienti/nori).
 
 Sono perfetti per i bento box e come cibo da viaggio. Il ripieno al tonno e maionese (chiamato _Tsunamayo_, ツナマヨ, in Giappone) è uno dei più diffusi e apprezzati, unendo il sapore sapido del tonno con la dolcezza e la cremosità della maionese.
 
-## Ingredienti (per 2 onigiri belli cicciotti)
-
+## Ingredienti
 - 1 tazza di [Riso per sushi](/ingredienti/rice)
 - 1 tazza e un cicinino di più di acqua
 - 120g di Tonno sott'olio (o al naturale)

--- a/docs/ricette/riso/oyakodon.md
+++ b/docs/ricette/riso/oyakodon.md
@@ -6,26 +6,26 @@ description: L'Oyakodon e' la carbonara giapponese
 slug: /ricette/oyakodon
 image: /img/ricette/oyakodon.jpg
 ingredients:
-- cipolla bianca
-- cipolline o negi o prezzemolo
-- cosce di pollo
-- dashi
-- mirin
-- olio di semi di arachide
-- riso bianco
-- sake
-- salsa di soia
-- uova grandi
+  - cipolla bianca
+  - cipolline o negi o prezzemolo
+  - cosce di pollo
+  - dashi
+  - mirin
+  - olio di semi di arachide
+  - riso bianco
+  - sake
+  - salsa di soia
+  - uova grandi
 tags:
-- mirin
-- negi
-- rice
-- sake
+  - mirin
+  - negi
+  - rice
+  - sake
+recipeYield: 1 persona
 ---
 <ImageComponent />
 
-## Ingredienti per 1 persona
-
+## Ingredienti
 - riso bianco
 - 2 uova grandi
 - 60 ml [dashi](/ricette/dashi)

--- a/docs/ricette/riso/soborodon.md
+++ b/docs/ricette/riso/soborodon.md
@@ -2,35 +2,37 @@
 title: Soboro Don
 sidebar_custom_props:
   subtitle: Uova e pollo macinato su una ciotola di riso
-description: La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine
+description: >-
+  La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova
+  strapazzate, perfetta per un pasto ricco di proteine
 slug: /ricette/soboro-don
 image: /img/ricette/soboro_don.jpg
 ingredients:
-- riso
-- pollo
-- uova
-- piselli
-- beni shoga
-- mirin
-- sake
-- zenzero
-- salsa di soia
+  - riso
+  - pollo
+  - uova
+  - piselli
+  - beni shoga
+  - mirin
+  - sake
+  - zenzero
+  - salsa di soia
 tags:
-- beni_shoga
-- mirin
-- shoyu
-- rice
-- sake
-- pollo
-- uova
+  - beni_shoga
+  - mirin
+  - shoyu
+  - rice
+  - sake
+  - pollo
+  - uova
+recipeYield: 2 persone
 ---
 
 Spesso chi fa sport o cerca un pasto ricco di proteine finisce per ripiegare sul tristissimo e monotono "riso e tonno". Il Giappone, però, ci offre un'alternativa fantastica, colorata e infinitamente più saporita: il Soboro Don. Il termine *soboro* indica una preparazione a base di carne, pesce o uova cotti e "sbriciolati" finemente. In questa versione, andiamo a creare una ciotola (donburi) bellissima da vedere, amata da grandi e piccini, dove il sapore umami del pollo si sposa alla perfezione con la dolcezza delle uova e la base neutra del riso.
 
 <ImageComponent />
 
-## Ingredienti per 2 persone
-
+## Ingredienti
 - [Riso](/ingredienti/rice) bianco cotto al vapore q.b.
 - 2 uova
 - 200g di carne macinata di pollo

--- a/docs/ricette/riso/soborodon.md
+++ b/docs/ricette/riso/soborodon.md
@@ -2,9 +2,7 @@
 title: Soboro Don
 sidebar_custom_props:
   subtitle: Uova e pollo macinato su una ciotola di riso
-description: >-
-  La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova
-  strapazzate, perfetta per un pasto ricco di proteine
+description: "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine"
 slug: /ricette/soboro-don
 image: /img/ricette/soboro_don.jpg
 ingredients:

--- a/docs/ricette/riso/takenoko_gohan.md
+++ b/docs/ricette/riso/takenoko_gohan.md
@@ -2,25 +2,28 @@
 title: Takenoko Gohan
 sidebar_custom_props:
   subtitle: Riso con germogli di bambù
-description: "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi."
+description: >-
+  Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di
+  bambù, aburaage e brodo dashi.
 slug: /ricette/takenoko_gohan
 image: /img/ricette/takenoko_gohan.jpg
 ingredients:
-- Riso
-- Germogli di bambù
-- Aburaage
-- Dashi
-- Shoyu
-- Mirin
-- Kinome
+  - Riso
+  - Germogli di bambù
+  - Aburaage
+  - Dashi
+  - Shoyu
+  - Mirin
+  - Kinome
 tags:
-- mirin
-- rice
-- shoyu
+  - mirin
+  - rice
+  - shoyu
+recipeYield: 2 persone
 ---
 <ImageComponent />
 
-## Ingredienti (per 2 persone / 2 "go" di riso)
+## Ingredienti
 - 2 misurini di [Riso](/ingredienti/rice) (circa 300g)
 - 120-150g di Germogli di bambù già bolliti
 - 1 foglio piccolo di Aburaage (tofu fritto sottile)

--- a/docs/ricette/riso/takenoko_gohan.md
+++ b/docs/ricette/riso/takenoko_gohan.md
@@ -2,9 +2,7 @@
 title: Takenoko Gohan
 sidebar_custom_props:
   subtitle: Riso con germogli di bambù
-description: >-
-  Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di
-  bambù, aburaage e brodo dashi.
+description: "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi."
 slug: /ricette/takenoko_gohan
 image: /img/ricette/takenoko_gohan.jpg
 ingredients:

--- a/docs/ricette/riso/takikomi_gohan.md
+++ b/docs/ricette/riso/takikomi_gohan.md
@@ -2,9 +2,7 @@
 title: Takikomi Gohan
 sidebar_custom_props:
   subtitle: Riso misto svuotafrigo
-description: >-
-  Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella
-  risiera
+description: "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera"
 slug: /ricette/takikomi_gohan
 ingredients:
   - carota

--- a/docs/ricette/riso/takikomi_gohan.md
+++ b/docs/ricette/riso/takikomi_gohan.md
@@ -2,28 +2,30 @@
 title: Takikomi Gohan
 sidebar_custom_props:
   subtitle: Riso misto svuotafrigo
-description: Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera
+description: >-
+  Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella
+  risiera
 slug: /ricette/takikomi_gohan
 ingredients:
-- carota
-- dashi
-- mirin
-- pollo
-- tonno in scatola
-- riso
-- sale
-- salsa di soia
-- shiitake
+  - carota
+  - dashi
+  - mirin
+  - pollo
+  - tonno in scatola
+  - riso
+  - sale
+  - salsa di soia
+  - shiitake
 tags:
-- mirin
-- rice
-- shiitake
+  - mirin
+  - rice
+  - shiitake
+recipeYield: 1 persona
 ---
 Il Takikomi gohan e' il riso misto con quello che vuoi dentro, cotto direttamente nella risiera.
 Piatto superveloce per tutti i giorni, metti nella risiera e dimentica.
 
-## Ingredienti per 1 persona
-
+## Ingredienti
 - 1 tazza di riso
 - 1 cucchiaio di [salsa di soia](/ingredienti/shoyu)
 - 1 cucchiaio di [mirin](/ingredienti/mirin)

--- a/docs/ricette/sides/nasu_dengaku.md
+++ b/docs/ricette/sides/nasu_dengaku.md
@@ -20,7 +20,7 @@ Per la glassatura di miso, miso bianco o rosso (o mix) 2 cucchiai grandi, 2 cucc
 
 Meglio usare le melanzane lunghe e strette piuttosto che quelle tonde
 
-## Preprarazione
+## Preparazione
 
 Metti subito a scaldare il grill del forno
 

--- a/docs/ricette/tsukemono/ninniku-no-misozuke.md
+++ b/docs/ricette/tsukemono/ninniku-no-misozuke.md
@@ -23,7 +23,7 @@ Il Ninniku no Misozuke è una di quelle chicche della cucina giapponese che tras
 - 45ml di [mirin](/ingredienti/mirin)
 - 3 teste d'aglio
 
-## Preprarazione
+## Preparazione
 
 Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro.
 Tagliare gli spicchi per il lungo e togliere l'anima. Mettere gli spicchi d'aglio su una griglia, e lasciare asciugare tutta la notte.

--- a/docs/ricette/tsukemono/ninniku-shoyuzuke.md
+++ b/docs/ricette/tsukemono/ninniku-shoyuzuke.md
@@ -23,7 +23,7 @@ Il Ninniku Shoyuzuke è una preparazione semplice per chi ama i sapori intensi. 
 - 1 tazza di [salsa di soia](/ingredienti/shoyu)
 - 1/2 tazza di aceto di riso
 
-### Preprarazione
+### Preparazione
 
 Mettere la [salsa di soia](/ingredienti/shoyu), lo zucchero e l'aceto di riso in un pentolino, portare a bollore e spegnere il fuoco.
 Versare il preparato in un barattolo di vetro sterilizzato insieme all'aglio.
@@ -36,7 +36,7 @@ Chiudere il barattolo e mettere in frigo. Il composto e' pronto dopo 3-4 settima
 - 1 tazza di spicchi di aglio
 - [salsa di soia](/ingredienti/shoyu) sufficiente a coprire l'aglio
 
-### Preprarazione
+### Preparazione
 
 Mettere l'aglio in un barattolo di vetro, coprire con la [salsa di soia](/ingredienti/shoyu) e lasciarlo in frigo per almeno 3-4 settimane.
 
@@ -49,7 +49,7 @@ Mettere l'aglio in un barattolo di vetro, coprire con la [salsa di soia](/ingred
 - 1 1/4 tazza di [salsa di soia](/ingredienti/shoyu)
 - 2 cucchiai di zucchero
 
-### Preprarazione
+### Preparazione
 
 Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro.
 Mettere gli spicchi d'aglio nel barattolo sterilizzato e ricoprire di aceto, mettere in frigorifero per 2 settimane.

--- a/docs/ricette/yakimono/takoyaki.md
+++ b/docs/ricette/yakimono/takoyaki.md
@@ -5,5 +5,6 @@ sidebar_custom_props:
 description: Le meravigliose pallette di polpo giapponesi
 slug: /ricette/takoyaki
 image: /img/ricette/takoyaki.webp
+draft: true
 ---
 <ImageComponent />

--- a/docs/ricette/yakimono/teriyaki_chicken.md
+++ b/docs/ricette/yakimono/teriyaki_chicken.md
@@ -3,18 +3,18 @@ title: Pollo Teriyaki
 description: Il segreto per un pollo succoso e perfettamente caramellato
 slug: /ricette/pollo_teriyaki
 ingredients:
-- sovracosce di pollo
-- mirin
-- sake
-- salsa di soia
-- riso bianco
+  - sovracosce di pollo
+  - mirin
+  - sake
+  - salsa di soia
+  - riso bianco
+recipeYield: 1 persona
 ---
 Il Pollo Teriyaki è forse uno dei piatti giapponesi più conosciuti al mondo, ma spesso viene interpretato male con salse troppo dense o cotture aggressive. La parola "Teriyaki" descrive una tecnica di cottura specifica: *teri* significa "lucentezza" (data dallo zucchero del mirin) e *yaki* significa "grigliato". Prepararlo in casa è sorprendentemente semplice se si segue il metodo tradizionale, che punta tutto sulla pazienza e sull'equilibrio dei sapori. Il risultato è un pollo dalla pelle croccante e dorata, con una carne incredibilmente tenera e una glassa profumata che avvolge ogni morso.
 
 ![Pollo Teriyaki](/img/ricette/pollo_teriyaki.jpg)
 
-## Ingredienti per 1 persona
-
+## Ingredienti
 - 1 sovracoscia di pollo (preferibilmente con la pelle)
 - 3 cucchiai di [Mirin](/ingredienti/mirin)
 - 3 cucchiai di [Sake](/ingredienti/sake)

--- a/docs/ricette/zuppe/misoshiru.md
+++ b/docs/ricette/zuppe/misoshiru.md
@@ -6,16 +6,17 @@ description: Zuppa di miso
 slug: /ricette/zuppa_di_miso
 image: /img/ricette/misoshiru.jpg
 ingredients:
-- Negi o porro
-- Verdure a piacere
-- Tofu
-- Wakame
-- Dashi
-- Miso
+  - Negi o porro
+  - Verdure a piacere
+  - Tofu
+  - Wakame
+  - Dashi
+  - Miso
 tags:
-- miso
-- negi
-- wakame
+  - miso
+  - negi
+  - wakame
+recipeYield: 1 porzione
 ---
 La zuppa di miso (味噌汁, misoshiru) è una delle zuppe più iconiche della cucina giapponese. È un piatto semplice e nutriente, a base di [dashi](/ricette/dashi) e miso.
 
@@ -23,8 +24,7 @@ Questa è una versione base, ma il bello della zuppa di miso è proprio questo: 
 
 <ImageComponent />
 
-## Ingredienti (a porzione)
-
+## Ingredienti
 - 1 tazza di [dashi](/ricette/dashi)
 - 1 cucchiaio di miso
 - 1 cucchiaino di wakame essiccato

--- a/docs/ricette/zuppe/tonjiru.md
+++ b/docs/ricette/zuppe/tonjiru.md
@@ -2,29 +2,32 @@
 title: Tonjiru
 sidebar_custom_props:
   subtitle: Zuppa di maiale e verdure di radice
-description: La zuppa giapponese più confortante, un "reset dell'anima" ricco di maiale e verdure di radice.
+description: >-
+  La zuppa giapponese più confortante, un "reset dell'anima" ricco di maiale e
+  verdure di radice.
 slug: /ricette/tonjiru
 image: /img/ricette/tonjiru.jpg
 ingredients:
-- Pancetta di maiale
-- Daikon
-- Carote
-- Patate
-- Taro (Satoimo)
-- Cipolla
-- Cipollotto (Negi)
-- Konnyaku
-- Tofu
-- Dashi
-- Miso
-- Olio di sesamo
-- Zenzero
+  - Pancetta di maiale
+  - Daikon
+  - Carote
+  - Patate
+  - Taro (Satoimo)
+  - Cipolla
+  - Cipollotto (Negi)
+  - Konnyaku
+  - Tofu
+  - Dashi
+  - Miso
+  - Olio di sesamo
+  - Zenzero
 tags:
-- daikon
-- konnyaku
-- miso
-- sesame_oil
-- sesamo
+  - daikon
+  - konnyaku
+  - miso
+  - sesame_oil
+  - sesamo
+recipeYield: 4 persone
 ---
 Quando fa freddo e la vita non va come vorresti, questa è la zuppa che ti rimette al mondo. Il **Tonjiru** (o *Butajiru*) è la zuppa giapponese più buona e confortante che ci sia. È un piatto ricco e sostanzioso, quasi uno stufato, a base di maiale (il "Ton" o "Buta") e una montagna di verdure di radice, il tutto in un brodo saporito arricchito dal [miso](/ingredienti/miso).
 
@@ -32,8 +35,7 @@ E' un vero "reset dell'anima" e ne puoi fare un bel pentolone, cosi' lo puoi con
 
 <ImageComponent />
 
-## Ingredienti per 4 persone
-
+## Ingredienti
 * 250g di Pancetta di maiale (tagliata sottile)
 * 250g di [Daikon](/ingredienti/daikon)
 * 1 Carota

--- a/docs/ricette/zuppe/tonjiru.md
+++ b/docs/ricette/zuppe/tonjiru.md
@@ -2,9 +2,7 @@
 title: Tonjiru
 sidebar_custom_props:
   subtitle: Zuppa di maiale e verdure di radice
-description: >-
-  La zuppa giapponese più confortante, un "reset dell'anima" ricco di maiale e
-  verdure di radice.
+description: "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice."
 slug: /ricette/tonjiru
 image: /img/ricette/tonjiru.jpg
 ingredients:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "prebuild": "node scripts/generate-image-metadata.js && node scripts/generate-ingredient-recipes.js && node scripts/optimize-images.js",
+    "prebuild": "node scripts/generate-image-metadata.js && node scripts/generate-ingredient-recipes.js && node scripts/generate-recipe-data.js && node scripts/optimize-images.js",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/scripts/generate-ingredient-recipes.js
+++ b/scripts/generate-ingredient-recipes.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const matter = require('gray-matter');
 
 const DOCS_ROOT = path.join(process.cwd(), 'docs');
 const RECIPES_ROOT = path.join(DOCS_ROOT, 'ricette');
@@ -10,7 +11,7 @@ function readFiles(dir) {
   return entries.flatMap((entry) => {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) return readFiles(fullPath);
-    if (!entry.name.endsWith('.md')) return [];
+    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx')) return [];
     return [fullPath];
   });
 }
@@ -19,66 +20,15 @@ function normalize(text) {
   return text
     .toLowerCase()
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[̀-ͯ]/g, '')
     .replace(/[_-]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }
 
-function parseFrontmatter(content) {
-  if (!content.startsWith('---')) return null;
-  const end = content.indexOf('\n---', 3);
-  if (end === -1) return null;
-  const fm = content.slice(3, end).replace(/^\n/, '');
-  const lines = fm.split(/\r?\n/);
-
-  const data = {};
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
-    const keyMatch = /^([a-zA-Z0-9_]+):\s*(.*)$/.exec(line);
-    if (!keyMatch) {
-      i += 1;
-      continue;
-    }
-
-    const key = keyMatch[1];
-    const value = keyMatch[2];
-
-    if (value.startsWith('[') && value.endsWith(']')) {
-      data[key] = value
-        .slice(1, -1)
-        .split(',')
-        .map((item) => item.trim())
-        .filter(Boolean);
-      i += 1;
-      continue;
-    }
-
-    if (value === '') {
-      const list = [];
-      let j = i + 1;
-      while (j < lines.length && /^\s*-\s+/.test(lines[j])) {
-        list.push(lines[j].replace(/^\s*-\s+/, '').trim());
-        j += 1;
-      }
-      if (list.length > 0) {
-        data[key] = list;
-        i = j;
-        continue;
-      }
-    }
-
-    data[key] = value.replace(/^"|"$/g, '').trim();
-    i += 1;
-  }
-
-  return data;
-}
-
 function toDocId(filePath) {
   const rel = path.relative(DOCS_ROOT, filePath);
-  return rel.replace(/\\/g, '/').replace(/\.md$/, '');
+  return rel.replace(/\\/g, '/').replace(/\.(md|mdx)$/, '');
 }
 
 function toPermalink(docId, slug) {
@@ -93,8 +43,9 @@ const index = {};
 
 for (const filePath of files) {
   const content = fs.readFileSync(filePath, 'utf8');
-  const fm = parseFrontmatter(content);
-  if (!fm) continue;
+  const {data: fm} = matter(content);
+
+  if (fm.draft === true) continue;
 
   const tags = Array.isArray(fm.tags) ? fm.tags : [];
   if (tags.length === 0) continue;
@@ -105,7 +56,7 @@ for (const filePath of files) {
   const permalink = toPermalink(docId, fm.slug);
 
   for (const tag of tags) {
-    const key = normalize(tag);
+    const key = normalize(typeof tag === 'string' ? tag : String(tag));
     if (!key) continue;
     if (!index[key]) index[key] = [];
     index[key].push({

--- a/scripts/generate-recipe-data.js
+++ b/scripts/generate-recipe-data.js
@@ -135,12 +135,14 @@ function extractRecipe(filePath) {
 
   const sections = parseSections(body);
 
-  // Prima sezione il cui titolo corrisponde a "Ingredienti" (case-insensitive)
+  // Prima sezione il cui titolo e' esattamente "Ingredienti" (case-insensitive).
+  // Eventuali varianti tipo "Ingredienti per N persone" vanno rinominate nel
+  // body e il yield va spostato nel frontmatter `recipeYield`.
   const ingrSection = sections.find((s) => /^ingredienti$/i.test(s.title));
   const recipeIngredient = ingrSection ? parseList(ingrSection.content) : [];
 
-  // Prima sezione il cui titolo corrisponde a Prep[*]azione (tollera typo)
-  const prepSection = sections.find((s) => /^prep[a-z]*azion[ei]$/i.test(s.title));
+  // Prima sezione il cui titolo e' esattamente "Preparazione".
+  const prepSection = sections.find((s) => /^preparazione$/i.test(s.title));
   const instructionsText = prepSection ? cleanInstructions(prepSection.content) : '';
 
   return {
@@ -150,6 +152,7 @@ function extractRecipe(filePath) {
     image: frontMatter.image ?? null,
     recipeCategory: categoryFromPath(filePath),
     recipeKeywords: Array.isArray(frontMatter.tags) ? frontMatter.tags : [],
+    recipeYield: typeof frontMatter.recipeYield === 'string' ? frontMatter.recipeYield : null,
     recipeIngredient,
     instructionsText,
   };
@@ -167,7 +170,7 @@ function main() {
   for (const r of recipes) byId[r.docId] = r;
 
   // Output: file TS con const RECIPE_DATA.
-  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeIngredient: string[];\n  instructionsText: string;\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
+  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeYield: string | null;\n  recipeIngredient: string[];\n  instructionsText: string;\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
 
   const body = JSON.stringify(byId, null, 2);
 

--- a/scripts/generate-recipe-data.js
+++ b/scripts/generate-recipe-data.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+/**
+ * Estrae da ogni file ricetta in docs/ricette/ il frontmatter + ingredienti
+ * e preparazione parsati dal body markdown, e produce
+ * src/data/recipe-data.ts. Il file viene poi consumato dal componente
+ * RecipeStructuredData per costruire lo schema JSON-LD Recipe.
+ *
+ * MVP: prima sezione "Ingredienti" (h2/h3), prima sezione "Preparazione"
+ * (con tolleranza per typo "Preprarazione"). Iter 2: split per paragrafo
+ * delle istruzioni in HowToStep multipli.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const ROOT = process.cwd();
+const RICETTE_DIR = path.join(ROOT, 'docs/ricette');
+const OUTPUT_FILE = path.join(ROOT, 'src/data/recipe-data.ts');
+
+// Mapping cartella -> recipeCategory schema.org (italiano)
+const CATEGORY_MAP = {
+  agemono: 'Fritti',
+  antipasti: 'Antipasti',
+  fish: 'Pesce',
+  menrui: 'Noodles',
+  nimono: 'Stufati',
+  riso: 'Riso',
+  sides: 'Contorni',
+  tsukemono: 'Marinati',
+  yakimono: 'Griglia',
+  zuppe: 'Zuppe',
+  brodi: 'Brodi',
+  salse: 'Salse',
+  condimenti: 'Condimenti',
+  sushi_and_sashimi: 'Sushi',
+};
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if ((entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) && entry.name !== 'index.md') {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function stripInlineMarkdown(s) {
+  return s
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')   // [text](url) -> text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')          // bold
+    .replace(/__([^_]+)__/g, '$1')              // bold alt
+    .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '$1') // italic
+    .replace(/(?<!_)_([^_]+)_(?!_)/g, '$1')     // italic alt
+    .replace(/`([^`]+)`/g, '$1')                // inline code
+    .trim();
+}
+
+/**
+ * Split body markdown in blocchi delimitati dagli header (#, ##, ###...).
+ * Ogni blocco: { level, title, content }.
+ */
+function parseSections(body) {
+  const lines = body.split('\n');
+  const sections = [];
+  let current = null;
+  for (const line of lines) {
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (m) {
+      if (current) sections.push(current);
+      current = {level: m[1].length, title: m[2].trim(), lines: []};
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) sections.push(current);
+  return sections.map((s) => ({...s, content: s.lines.join('\n').trim()}));
+}
+
+function parseList(content) {
+  const items = [];
+  for (const line of content.split('\n')) {
+    const m = line.match(/^\s*[-*+]\s+(.+?)\s*$/);
+    if (m) items.push(stripInlineMarkdown(m[1]));
+  }
+  return items;
+}
+
+/**
+ * Pulisce il testo di una sezione di preparazione: rimuove admonitions,
+ * componenti MDX, link markdown, codice, e collassa righe multiple in un
+ * unico blob di testo separato da spazi (MVP: singolo HowToStep).
+ */
+function cleanInstructions(content) {
+  return content
+    .replace(/:::[^\n]*\n[\s\S]*?:::/g, '')             // admonitions
+    .replace(/<[A-Za-z][^>]*\/>/g, '')                   // self-closing JSX
+    .replace(/<[A-Za-z][^>]*>[\s\S]*?<\/[A-Za-z][^>]*>/g, '') // paired JSX
+    .split('\n')
+    .map((l) => stripInlineMarkdown(l).trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function docIdFromPath(filePath) {
+  // docs/ricette/agemono/kara-age.md -> ricette/agemono/kara-age
+  return path
+    .relative(path.join(ROOT, 'docs'), filePath)
+    .replace(/\\/g, '/')
+    .replace(/\.(md|mdx)$/, '');
+}
+
+function categoryFromPath(filePath) {
+  // docs/ricette/agemono/kara-age.md -> agemono
+  // docs/ricette/preparazioni_di_base/brodi/dashi.md -> brodi
+  const rel = path.relative(RICETTE_DIR, filePath).replace(/\\/g, '/');
+  const parts = rel.split('/');
+  // parts: ['agemono', 'kara-age.md'] OR ['preparazioni_di_base', 'brodi', 'dashi.md']
+  // Prendiamo l'ultima cartella prima del file.
+  const folder = parts[parts.length - 2];
+  return CATEGORY_MAP[folder] ?? null;
+}
+
+function extractRecipe(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const {data: frontMatter, content: body} = matter(raw);
+  const sections = parseSections(body);
+
+  // Prima sezione il cui titolo corrisponde a "Ingredienti" (case-insensitive)
+  const ingrSection = sections.find((s) => /^ingredienti$/i.test(s.title));
+  const recipeIngredient = ingrSection ? parseList(ingrSection.content) : [];
+
+  // Prima sezione il cui titolo corrisponde a Prep[*]azione (tollera typo)
+  const prepSection = sections.find((s) => /^prep[a-z]*azion[ei]$/i.test(s.title));
+  const instructionsText = prepSection ? cleanInstructions(prepSection.content) : '';
+
+  return {
+    docId: docIdFromPath(filePath),
+    title: frontMatter.title ?? '',
+    description: frontMatter.description ?? '',
+    image: frontMatter.image ?? null,
+    recipeCategory: categoryFromPath(filePath),
+    recipeKeywords: Array.isArray(frontMatter.tags) ? frontMatter.tags : [],
+    recipeIngredient,
+    instructionsText,
+  };
+}
+
+function main() {
+  const files = walk(RICETTE_DIR);
+  const recipes = files.map(extractRecipe).filter((r) => r.recipeIngredient.length > 0 || r.instructionsText.length > 0);
+
+  // Indicizza per docId
+  const byId = Object.create(null);
+  for (const r of recipes) byId[r.docId] = r;
+
+  // Output: file TS con const RECIPE_DATA.
+  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeIngredient: string[];\n  instructionsText: string;\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
+
+  const body = JSON.stringify(byId, null, 2);
+
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), {recursive: true});
+  fs.writeFileSync(OUTPUT_FILE, header + body + ';\n', 'utf-8');
+
+  console.log(`✅ Generated ${path.relative(ROOT, OUTPUT_FILE)} with ${Object.keys(byId).length} recipes.`);
+}
+
+main();

--- a/scripts/generate-recipe-data.js
+++ b/scripts/generate-recipe-data.js
@@ -129,6 +129,10 @@ function categoryFromPath(filePath) {
 function extractRecipe(filePath) {
   const raw = fs.readFileSync(filePath, 'utf-8');
   const {data: frontMatter, content: body} = matter(raw);
+
+  // Skip draft: true (Docusaurus stesso esclude la pagina dal build)
+  if (frontMatter.draft === true) return null;
+
   const sections = parseSections(body);
 
   // Prima sezione il cui titolo corrisponde a "Ingredienti" (case-insensitive)
@@ -153,7 +157,10 @@ function extractRecipe(filePath) {
 
 function main() {
   const files = walk(RICETTE_DIR);
-  const recipes = files.map(extractRecipe).filter((r) => r.recipeIngredient.length > 0 || r.instructionsText.length > 0);
+  const recipes = files
+    .map(extractRecipe)
+    .filter((r) => r !== null)
+    .filter((r) => r.recipeIngredient.length > 0 || r.instructionsText.length > 0);
 
   // Indicizza per docId
   const byId = Object.create(null);

--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {RECIPE_DATA, type RecipeData} from '@site/src/data/recipe-data';
+
+const FALLBACK_SITE_URL = 'https://paginegiappe.it';
+const AUTHOR = {
+  '@type': 'Person',
+  name: 'Stefano Guglielmetti',
+  url: 'https://paginegiappe.it/',
+};
+
+function absoluteUrl(siteUrl: string, p: string | null | undefined): string | undefined {
+  if (!p) return undefined;
+  if (/^https?:\/\//i.test(p)) return p;
+  return siteUrl.replace(/\/$/, '') + (p.startsWith('/') ? p : '/' + p);
+}
+
+/** Aggiunge trailing slash alle pagine HTML (coerente con trailingSlash: true). */
+function withTrailingSlash(p: string): string {
+  return p.endsWith('/') ? p : p + '/';
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\/+$/, '');
+}
+
+function buildRecipeSchema(
+  data: RecipeData,
+  permalink: string,
+  siteUrl: string,
+  dateModified: string | undefined,
+): Record<string, unknown> {
+  const keywordParts = [...data.recipeKeywords, 'ricetta giapponese', 'cucina giapponese'];
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Recipe',
+    name: data.title,
+    description: data.description,
+    url: absoluteUrl(siteUrl, withTrailingSlash(permalink)),
+    author: AUTHOR,
+    recipeCuisine: 'Giapponese',
+    keywords: keywordParts.join(', '),
+  };
+  const imageUrl = absoluteUrl(siteUrl, data.image);
+  if (imageUrl) schema.image = [imageUrl];
+  if (data.recipeCategory) schema.recipeCategory = data.recipeCategory;
+  if (data.recipeIngredient.length > 0) schema.recipeIngredient = data.recipeIngredient;
+  if (data.instructionsText) {
+    schema.recipeInstructions = [
+      {'@type': 'HowToStep', text: data.instructionsText},
+    ];
+  }
+  if (dateModified) schema.dateModified = dateModified;
+  return schema;
+}
+
+/**
+ * Inietta lo schema JSON-LD `Recipe` nelle pagine ricetta sotto /ricette/.
+ * PoC della Fase A4: attivo solo su 2 ricette campione (`dashi` e `kara-age`).
+ * Quando il Rich Results Test sarà verde, rimuovo il filtro per generalizzare.
+ */
+const POC_PATHS = new Set([
+  '/ricette/dashi',
+  '/ricette/kara-age',
+]);
+
+export default function RecipeStructuredData(): React.ReactElement | null {
+  const {siteConfig} = useDocusaurusContext();
+  const {metadata} = useDoc();
+  const siteUrl = siteConfig.url || FALLBACK_SITE_URL;
+
+  // Filtro PoC — togliere dopo OK Rich Results Test
+  if (!POC_PATHS.has(normalizePath(metadata.permalink))) return null;
+
+  const data = RECIPE_DATA[metadata.id];
+  if (!data) return null;
+
+  const dateModified = metadata.lastUpdatedAt
+    ? new Date(metadata.lastUpdatedAt).toISOString()
+    : undefined;
+
+  const schema = buildRecipeSchema(data, metadata.permalink, siteUrl, dateModified);
+
+  return (
+    <Head>
+      <script type="application/ld+json">{JSON.stringify(schema)}</script>
+    </Head>
+  );
+}

--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -46,6 +46,7 @@ function buildRecipeSchema(
   const imageUrl = absoluteUrl(siteUrl, data.image);
   if (imageUrl) schema.image = [imageUrl];
   if (data.recipeCategory) schema.recipeCategory = data.recipeCategory;
+  if (data.recipeYield) schema.recipeYield = data.recipeYield;
   if (data.recipeIngredient.length > 0) schema.recipeIngredient = data.recipeIngredient;
   if (data.instructionsText) {
     schema.recipeInstructions = [

--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -49,7 +49,12 @@ function buildRecipeSchema(
   if (data.recipeIngredient.length > 0) schema.recipeIngredient = data.recipeIngredient;
   if (data.instructionsText) {
     schema.recipeInstructions = [
-      {'@type': 'HowToStep', text: data.instructionsText},
+      {
+        '@type': 'HowToStep',
+        name: 'Preparazione',
+        text: data.instructionsText,
+        url: absoluteUrl(siteUrl, withTrailingSlash(permalink)) + '#preparazione',
+      },
     ];
   }
   if (dateModified) schema.dateModified = dateModified;
@@ -58,21 +63,14 @@ function buildRecipeSchema(
 
 /**
  * Inietta lo schema JSON-LD `Recipe` nelle pagine ricetta sotto /ricette/.
- * PoC della Fase A4: attivo solo su 2 ricette campione (`dashi` e `kara-age`).
- * Quando il Rich Results Test sarà verde, rimuovo il filtro per generalizzare.
+ * Attivo su tutte le pagine il cui docId e' presente in RECIPE_DATA
+ * (popolato dal prebuild script per ogni file md sotto docs/ricette/
+ * che ha sezioni "Ingredienti" o "Preparazione" parsabili).
  */
-const POC_PATHS = new Set([
-  '/ricette/dashi',
-  '/ricette/kara-age',
-]);
-
 export default function RecipeStructuredData(): React.ReactElement | null {
   const {siteConfig} = useDocusaurusContext();
   const {metadata} = useDoc();
   const siteUrl = siteConfig.url || FALLBACK_SITE_URL;
-
-  // Filtro PoC — togliere dopo OK Rich Results Test
-  if (!POC_PATHS.has(normalizePath(metadata.permalink))) return null;
 
   const data = RECIPE_DATA[metadata.id];
   if (!data) return null;

--- a/src/data/ingredient-recipes.ts
+++ b/src/data/ingredient-recipes.ts
@@ -3,7 +3,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/agemono/enoki_tatsuta-age",
       "title": "Enoki Tatsuta-age",
-      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso",
+      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso\"",
       "permalink": "/ricette/enoki-tatsuta-age"
     },
     {
@@ -23,7 +23,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/agemono/enoki_tatsuta-age",
       "title": "Enoki Tatsuta-age",
-      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso",
+      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso\"",
       "permalink": "/ricette/enoki-tatsuta-age"
     },
     {
@@ -79,7 +79,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/agemono/enoki_tatsuta-age",
       "title": "Enoki Tatsuta-age",
-      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso",
+      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso\"",
       "permalink": "/ricette/enoki-tatsuta-age"
     },
     {
@@ -139,7 +139,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
+      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -147,7 +147,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/agemono/enoki_tatsuta-age",
       "title": "Enoki Tatsuta-age",
-      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso",
+      "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso\"",
       "permalink": "/ricette/enoki-tatsuta-age"
     },
     {
@@ -717,7 +717,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
+      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -887,7 +887,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
+      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -1347,7 +1347,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
+      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     },
     {
@@ -1375,7 +1375,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
+      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ]

--- a/src/data/ingredient-recipes.ts
+++ b/src/data/ingredient-recipes.ts
@@ -47,13 +47,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": ">-",
+      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -139,7 +139,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": ">-",
+      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -221,7 +221,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/nimono/nikujaga",
       "title": "Nikujaga",
-      "description": ">-",
+      "description": "Carne e patate, il comfort food per eccellenza della cucina casalinga giapponese",
       "permalink": "/ricette/nikujaga"
     },
     {
@@ -275,13 +275,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": ">-",
+      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -293,7 +293,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": ">-",
+      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -441,7 +441,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     },
     {
@@ -511,13 +511,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": ">-",
+      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
       "permalink": "/ricette/dashi_vegan"
     },
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": ">-",
+      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -555,7 +555,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -629,7 +629,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -717,7 +717,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": ">-",
+      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -763,7 +763,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": ">-",
+      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
       "permalink": "/ricette/dashi_vegan"
     },
     {
@@ -887,7 +887,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": ">-",
+      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -919,7 +919,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": ">-",
+      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
       "permalink": "/ricette/dashi_vegan"
     },
     {
@@ -977,7 +977,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -997,7 +997,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -1011,7 +1011,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -1061,7 +1061,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": ">-",
+      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
       "permalink": "/ricette/natto_soba"
     }
   ],
@@ -1089,7 +1089,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1155,7 +1155,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": ">-",
+      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
       "permalink": "/ricette/dashi_vegan"
     }
   ],
@@ -1211,13 +1211,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": ">-",
+      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -1229,7 +1229,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": ">-",
+      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -1275,7 +1275,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1283,7 +1283,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": ">-",
+      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1347,7 +1347,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": ">-",
+      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     },
     {
@@ -1375,7 +1375,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": ">-",
+      "description": "La zuppa giapponese più confortante, un \\\"reset dell'anima\\\" ricco di maiale e verdure di radice.",
       "permalink": "/ricette/tonjiru"
     }
   ]

--- a/src/data/ingredient-recipes.ts
+++ b/src/data/ingredient-recipes.ts
@@ -47,13 +47,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
+      "description": ">-",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -139,7 +139,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+      "description": ">-",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -221,7 +221,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/nimono/nikujaga",
       "title": "Nikujaga",
-      "description": "Carne e patate, il comfort food per eccellenza della cucina casalinga giapponese",
+      "description": ">-",
       "permalink": "/ricette/nikujaga"
     },
     {
@@ -275,13 +275,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
+      "description": ">-",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -293,7 +293,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
+      "description": ">-",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -441,7 +441,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     },
     {
@@ -511,13 +511,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
+      "description": ">-",
       "permalink": "/ricette/dashi_vegan"
     },
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
+      "description": ">-",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -555,7 +555,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -629,7 +629,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -717,7 +717,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+      "description": ">-",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -763,7 +763,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
+      "description": ">-",
       "permalink": "/ricette/dashi_vegan"
     },
     {
@@ -887,7 +887,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+      "description": ">-",
       "permalink": "/ricette/tonjiru"
     }
   ],
@@ -919,7 +919,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
+      "description": ">-",
       "permalink": "/ricette/dashi_vegan"
     },
     {
@@ -977,7 +977,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -997,7 +997,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -1011,7 +1011,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     },
     {
@@ -1061,7 +1061,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/menrui/natto_soba",
       "title": "Natto Soba",
-      "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+      "description": ">-",
       "permalink": "/ricette/natto_soba"
     }
   ],
@@ -1089,7 +1089,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1155,7 +1155,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/preparazioni_di_base/brodi/vegan_dashi",
       "title": "Dashi Vegano",
-      "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
+      "description": ">-",
       "permalink": "/ricette/dashi_vegan"
     }
   ],
@@ -1211,13 +1211,13 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     },
     {
       "id": "ricette/riso/takenoko_gohan",
       "title": "Takenoko Gohan",
-      "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
+      "description": ">-",
       "permalink": "/ricette/takenoko_gohan"
     },
     {
@@ -1229,7 +1229,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/takikomi_gohan",
       "title": "Takikomi Gohan",
-      "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
+      "description": ">-",
       "permalink": "/ricette/takikomi_gohan"
     },
     {
@@ -1275,7 +1275,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1283,7 +1283,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/riso/soborodon",
       "title": "Soboro Don",
-      "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+      "description": ">-",
       "permalink": "/ricette/soboro-don"
     }
   ],
@@ -1347,7 +1347,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+      "description": ">-",
       "permalink": "/ricette/tonjiru"
     },
     {
@@ -1375,7 +1375,7 @@ export const INGREDIENT_RECIPE_INDEX = {
     {
       "id": "ricette/zuppe/tonjiru",
       "title": "Tonjiru",
-      "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+      "description": ">-",
       "permalink": "/ricette/tonjiru"
     }
   ]

--- a/src/data/recipe-data.ts
+++ b/src/data/recipe-data.ts
@@ -1,0 +1,1336 @@
+// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.
+// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.
+
+export interface RecipeData {
+  docId: string;
+  title: string;
+  description: string;
+  image: string | null;
+  recipeCategory: string | null;
+  recipeKeywords: string[];
+  recipeIngredient: string[];
+  instructionsText: string;
+}
+
+export const RECIPE_DATA: Record<string, RecipeData> = {
+  "ricette/agemono/enoki_tatsuta-age": {
+    "docId": "ricette/agemono/enoki_tatsuta-age",
+    "title": "Enoki Tatsuta-age",
+    "description": "Funghi enoki croccanti e saporiti, il contorno perfetto \"ladro di riso\"",
+    "image": "/img/ricette/enoki-tatsuta-age.jpg",
+    "recipeCategory": "Fritti",
+    "recipeKeywords": [
+      "enoki",
+      "shoyu",
+      "sesamo",
+      "potato_starch"
+    ],
+    "recipeIngredient": [
+      "1 confezione di funghi enoki",
+      "2 cucchiai di salsa di soia o salsa yakiniku",
+      "½ cucchiaio di maionese tipo Kewpie",
+      "2 cm di pasta di zenzero fresco",
+      "2 cm di pasta d'aglio",
+      "1 cucchiaio di semi di sesamo",
+      "3 cucchiai di fecola di patate (katakuriko)",
+      "Olio di semi per friggere q.b."
+    ],
+    "instructionsText": "Iniziamo preparando i funghi enoki. È importante rimuovere la base (la parte terrosa), ma fate attenzione a non tagliare troppo in alto: i funghi devono rimanere uniti alla base per facilitare la frittura e mantenere la forma a ventaglio. Una volta puliti, dividete il mazzo in circa 8 piccoli mazzetti. Prendete un sacchetto per alimenti in plastica (tipo quelli per il gelo) e inserite i mazzetti di enoki insieme alla salsa di soia (o yakiniku), alla maionese, allo zenzero e all'aglio. Chiudete il sacchetto e massaggiate delicatamente affinché la marinatura penetri bene tra le fibre dei funghi. Lasciate riposare per circa 10 minuti in modo che i sapori vengano assorbiti. Passato il tempo di marinatura, scolate i funghi dal liquido in eccesso e trasferiteli in un nuovo sacchetto pulito. Aggiungete i semi di sesamo e la fecola di patate. Il segreto per una panatura perfetta è aggiungere la fecola un cucchiaio alla volta, scuotendo bene il sacchetto per distribuirla uniformemente su ogni mazzetto. In una padella antiaderente, scaldate una piccola quantità di olio di semi a fuoco medio. Quando l'olio è ben caldo, adagiate i mazzetti di enoki ben distanziati tra loro. Friggete finché non raggiungono un bel colore dorato e una consistenza croccante su entrambi i lati."
+  },
+  "ricette/agemono/kara-age": {
+    "docId": "ricette/agemono/kara-age",
+    "title": "Kara-Age",
+    "description": "Il pollo fritto piu' buono del mondo",
+    "image": "/img/ricette/karaage.jpg",
+    "recipeCategory": "Fritti",
+    "recipeKeywords": [
+      "mirin",
+      "potato_starch",
+      "kewpie",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "Coscia e sottocoscia di pollo disossata, con la pelle",
+      "1 cucchiaio di salsa di soia",
+      "1 cucchiaio di mirin",
+      "1 cucchiaio di sake",
+      "1 spicchio d'aglio",
+      "1 pezzetto di zenzero, grande piu' o meno come l'aglio",
+      "Fecola di patate per infarinare",
+      "Olio per friggere (arachide o girasole o canola)"
+    ],
+    "instructionsText": "Tagliare il pollo in cubetti di circa 4 centimetri di lato, l'importante è che siano tutti più o meno delle stesse dimensioni, così che si cuociano uniformemente, meglio pezzi un po' piu cicciottelli che restano piu' umidi e danno piu' gusto. Preparare la marinatura, unendo mirin, sake, salsa di soia, e zenzero e aglio grattugiati (o spremuti brutalmente con uno schiaccia aglio). Mettere tutto in una ciotola, coprire con la pellicola e lasciar marinare in frigo per minimo 2 ore, anche se 24 ore e' l'ideale. Dopo la marinatura, infarinare il pollo nella fecola di patate, senza lasciare zone scoperte. Cercare di rimuovere tutta la farina in eccesso, facendo una infarinatura uniforme e leggera. Scaldare l’olio a 160 gradi e friggere una volta (4-5 pezzetti di pollo alla volta, in modo che non si attacchino tra di loro) per circa 90-120 secondi a seconda delle dimensioni del pollo. Lasciare scolare e riposare il pollo per qualche minuto, poi friggere nuovamente, questa volta a 180 gradi per circa 45 secondi - 1 minuto. Di nuovo far asciugare su una griglia, e gustare con la salsa (io uso Maionese Kewpie condita con lo shichimi togarashi). In alternativa, come facciamo anche noi con i fritti, potete gustarlo con una fettina di limone spremuta."
+  },
+  "ricette/antipasti/chawanmushi": {
+    "docId": "ricette/antipasti/chawanmushi",
+    "title": "Chawanmushi",
+    "description": "Budino di uova cotto al vapore",
+    "image": "/img/ricette/chawanmushi.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "ginnan",
+      "mirin",
+      "sake",
+      "shiitake"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Unire in una ciotola le uova, con il dashi, il mirin, la salsa di soia (se si vuole, il sake) e il sale. Mescolare bene con luna frusta, cercando di non incorporare aria. Setacciare il composto con un colino a maglie strette in un'altra ciotola, e versare il composto nelle ciotoline di ceramica. Mettere nelle ciotoline uno o due gamberi, un paio di ginnan, e un fungo shiitake fatto a fettine. Versare il composto nelle ciotoline, e coprire con un foglio di alluminio. Mettere le ciotoline nella pentola per il vapore, e cuocere a circa 90 gradi per 10 minuti. La cosa piu' semplice per mantenere la temperatura é mettere una bacchetta tra il coperchio e la pentola, per tenere il coperchio socchiuso. Tenere la fiamma appena sufficiente a far sobbollire l'acqua. A questo punto si possono aggiungere altre decorazioni, come l'edamame, o un gambero o delle capesante fatte a fettine, e cuocere per altri 2 minuti. Altrimenti, si puo' cuocere per 12-13 minuti senza aggiungere nulla. Spegnere il fuoco, e lasciare riposare per 7-8 minuti. A questo punto aggiungere un po' di prezzemolo o cipolline, e servire caldo. Alternativamente, si puo' mettere in frigorifero e gustare freddo, con del buon vino bianco o del sake."
+  },
+  "ricette/antipasti/hiyashi_nasu": {
+    "docId": "ricette/antipasti/hiyashi_nasu",
+    "title": "Hiyashi Nasu",
+    "description": "Un piatto tipico degli Izakaya giapponesi, semplicissimo e incredibilmente buono.",
+    "image": "/img/ricette/hiyashi_nasu.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "katsuobushi"
+    ],
+    "recipeIngredient": [
+      "1 o 2 Melanzane piccole e sode",
+      "Cipolline verdi",
+      "Salsa di soia",
+      "Katsuobushi"
+    ],
+    "instructionsText": "Sbucciare completamente la melanzana con un pelapatate. Avvolgerla poi molto stretta in un foglio di carta da cucina. Passare la melanzana avvolta sotto l'acqua corrente, bagnando uniformemente la carta. Strizzarla bene per eliminare l'acqua in eccesso. Avvolgere nuovamente il tutto, ben stretto, con della pellicola per alimenti adatta al microonde. Cuocere la melanzana nel microonde per 3 minuti alla massima potenza. Questo metodo è una scorciatoia per la classica cottura al vapore. Appena finita la cottura, scartare immediatamente la melanzana dalla pellicola e dalla carta. Lasciarla raffreddare prima a temperatura ambiente, poi metterla in un contenitore e trasferirla in frigorifero finché non sarà completamente fredda. Prendere la melanzana fredda dal frigo e tagliarla a fette o a tocchetti. Disporla su un piattino. Guarnire con le cipolline affettate finemente, condire con un po' di salsa di soia e completare con una generosa manciata di katsuobushi. Provate assolutamente a rifarlo perché è veramente buono, buono, buono. Itadakimasu!"
+  },
+  "ricette/antipasti/hiyayakko": {
+    "docId": "ricette/antipasti/hiyayakko",
+    "title": "Hiyayakko",
+    "description": "Tofu freddo con condimento",
+    "image": "/img/ricette/hiyayakko.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "katsuobushi",
+      "negi"
+    ],
+    "recipeIngredient": [
+      "1 panetto di tofu morbido (meglio se silken tofu)",
+      "2-3 cucchiai di salsa ponzu",
+      "Katsuobushi, una manciatina",
+      "Zenzero, grattugiato fresco",
+      "Cipollina verde o negi affettata sottilmente"
+    ],
+    "instructionsText": "Togli il tofu dalla confezione e scolalo delicatamente. Se ha molta acqua, lascialo riposare qualche minuto su carta da cucina per farlo asciugare leggermente, senza romperlo. Taglialo in 2 o 4 pezzi, oppure lascialo intero se lo servi in una sola porzione, e mettilo in una ciotolina o piattino fondo. Versa sopra la salsa ponzu, quanto basta per condirlo ma senza affogarlo. Guarnisci con una grattugiata di zenzero fresco, katsuobushi a piacere, e cipollina verde affettata."
+  },
+  "ricette/antipasti/nama_harumaki": {
+    "docId": "ricette/antipasti/nama_harumaki",
+    "title": "Nama Harumaki",
+    "description": "Gli involtini primavera giapponesi in carta di riso, freschi e non fritti, ripieni di pollo teriyaki",
+    "image": "/img/ricette/nama_harumaki.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "kewpie",
+      "teriyaki"
+    ],
+    "recipeIngredient": [
+      "Fogli di carta di riso rotondi",
+      "Alette di pollo (o avanzi di pollo arrosto/sfilacciato)",
+      "Salsa Teriyaki (preparata in casa o pronta)",
+      "Mezza carota",
+      "Foglie di senape Mizuna (o in alternativa della comune insalata riccia)",
+      "Maionese Kewpie"
+    ],
+    "instructionsText": "Per il ripieno, iniziamo dalla preparazione del pollo. In questa ricetta utilizziamo delle alette, pre-cuocendole per una decina di minuti in friggitrice ad aria a 160 gradi. Una volta cotte, priviamole delle ossa sfilacciando la carne grossolanamente con le mani. Trasferiamo il pollo sfilacciato in una padella ben calda e versiamo la nostra salsa teriyaki, lasciando sfrigolare e caramellare i pezzetti di carne fino a renderli lucidi, appiccicosi e irresistibili. Passiamo alle verdure. Mondiamo la carota e la tagliamo a bastoncini sottili e regolari (hosogiri). Laviamo accuratamente le foglie di mizuna, una senape giapponese dal sapore leggermente pungente; se non riuscite a trovarla, una normalissima insalata riccia andrà benissimo per replicare la croccantezza necessaria. A questo punto prepariamo la postazione per l'assemblaggio. Prendiamo un foglio di carta di riso e lo inumidiamo delicatamente su ambo i lati con dell'acqua per farlo ammorbidire. Lo stendiamo sul tagliere e iniziamo a comporre il nostro involtino: posizioniamo prima un letto di foglie di mizuna, aggiungiamo una generosa e voluttuosa striscia di maionese Kewpie, adagiamo il pollo teriyaki caramellato e completiamo con i bastoncini di carota. Ora arriva il momento di mettere in pratica la memoria muscolare per chiudere l'involtino. Solleviamo il lembo inferiore della carta di riso coprendo il ripieno e stringendo bene con le dita. Ripieghiamo i bordi laterali verso l'interno per sigillare i lati, dopodiché continuiamo ad arrotolare l'involtino su se stesso esercitando una leggera pressione, fino a chiuderlo completamente in un cilindro compatto. I nostri Nama Harumaki sono pronti da tagliare a metà e gustare, tanto belli da vedere quanto buoni da mangiare."
+  },
+  "ricette/antipasti/sunomono": {
+    "docId": "ricette/antipasti/sunomono",
+    "title": "Sunomono di Cetrioli e Wakame (con variante al Polpo)",
+    "description": "Insalatine giapponesi con condimento a base di aceto, perfette per l'estate.",
+    "image": "/img/ricette/sunomono.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "sesame_oil",
+      "sesamo",
+      "wakame"
+    ],
+    "recipeIngredient": [
+      "1 Cetriolo (se lo trovate, è molto meglio quello giapponese: stretto, lungo e sbruzzoloso)",
+      "Alghe Wakame essiccate",
+      "Polpo già lessato (per la versione \"super lusso\")",
+      "Sushisu (l'aceto per sushi)",
+      "Salsa di soia (Shoyu)",
+      "Olio di sesamo (qualche goccia, volendo)",
+      "Semi di sesamo tostati",
+      "Sale fino"
+    ],
+    "instructionsText": ""
+  },
+  "ricette/antipasti/yamitsuki_kyabesu": {
+    "docId": "ricette/antipasti/yamitsuki_kyabesu",
+    "title": "Yamitsuki Kyabesu",
+    "description": "Il cavolo che te da la rota!",
+    "image": "/img/ricette/yamitsuki_kyabesu.jpg",
+    "recipeCategory": "Antipasti",
+    "recipeKeywords": [
+      "vegan",
+      "sesame_oil",
+      "sesamo"
+    ],
+    "recipeIngredient": [
+      "Un quarto abbondante di Cavolo cappuccio",
+      "1 cucchiaio di Olio di sesamo",
+      "Una manciata di Semi di sesamo tostati",
+      "1 cucchiaino di Sale",
+      "1 cucchiaino di Brodo vegetale in polvere (in sostituzione del Kombucha in polvere)"
+    ],
+    "instructionsText": "Prendere un contenitore di plastica con coperchio. Tagliare il cavolo cappuccio a quadratoni grossolani, senza essere troppo precisi, e separare le foglie con le mani. Mettere il cavolo tagliato nel contenitore. Aggiungere direttamente sul cavolo un cucchiaio di olio di sesamo, il brodo granulare, il sale e una generosa manciata di semi di sesamo. Chiudere il contenitore con il suo coperchio. Adesso arriva la parte divertente: shakerare fortissimo per qualche secondo, in modo da distribuire uniformemente il condimento e ammorbidire leggermente il cavolo. Aprire, trasferire in una ciotola e servire subito. È già pronta."
+  },
+  "ricette/fish/sudako_negi_vapore": {
+    "docId": "ricette/fish/sudako_negi_vapore",
+    "title": "Sudako con Negi al Vapore",
+    "description": "Moscardini bolliti e cipollotti al vapore conditi con una salsa agrodolce all'aceto e pepe nero",
+    "image": null,
+    "recipeCategory": "Pesce",
+    "recipeKeywords": [
+      "negi",
+      "shoyu"
+    ],
+    "recipeIngredient": [
+      "Moscardini (Iidako)",
+      "Negi (cipollotti lunghi o porri giapponesi)",
+      "Sale abbondante per la pulizia",
+      "Pepe nero"
+    ],
+    "instructionsText": "Metti i moscardini in una ciotola di terracotta (o una ciotola capiente). Aggiungi abbondante sale e massaggiali con cura ed energia. Fallo finché non ti sembra di star esagerando: quella è la quantità giusta di frizione. Sciacquali molto bene sotto l'acqua corrente per rimuovere tutto il sale e le impurità. Porta a bollore una pentola d'acqua e aggiungi sale. Immergi i moscardini tenendoli per la testa e bagnando prima solo le punte dei tentacoli ripetutamente (\"choi choi\"). Facendo così, i tentacoli si arricceranno verso l'esterno e prenderanno una bella forma una volta cotti. Quando la testa diventa dura e compatta al tatto, sono pronti. Scolali. Prendi il negi e taglialo diagonalmente a pezzi grossolani. Mettili in un cestello per la cottura al vapore e cuocili finché non diventano teneri e dolci. Nel frattempo prepara la salsa: in un pentolino metti un cucchiaio di zucchero e il doppio della quantità di aceto. Scalda leggermente solo per far sciogliere lo zucchero. Lascia raffreddare e aggiungi una piccolissima quantità di shoyu. Taglia i moscardini bolliti a pezzi facili da mangiare (la tecnica di taglio dipende dai gusti). Impiattamento: disponi il negi cotto al vapore sul fondo del piatto, spargi sopra i pezzi di moscardino. Condisci versando la salsa agrodolce (amazu) e completa con una spolverata di pepe nero. Itadakimasu!"
+  },
+  "ricette/fish/teriyaki_salmon": {
+    "docId": "ricette/fish/teriyaki_salmon",
+    "title": "Salmone Teriyaki",
+    "description": "Salmone in padella con salsa Teriyaki",
+    "image": "/img/ricette/teriyaki_salmon.webp",
+    "recipeCategory": "Pesce",
+    "recipeKeywords": [
+      "sake"
+    ],
+    "recipeIngredient": [
+      "Salmone",
+      "Sale",
+      "Pepe nero appena macinato",
+      "Farina bianca",
+      "Olio da cucina o burro",
+      "1 cucchiaio di sake",
+      "Salsa Teriyaki"
+    ],
+    "instructionsText": "Condire il salmone con sale e pepe nero appena macinato, poi passarlo leggermente nella farina bianca. Scaldare l'olio da cucina o il burro in una padella e cuocere il salmone per 3 minuti da un lato fino a doratura. Girare il salmone, aggiungere 1 cucchiaio di sake e coprire la padella per cuocere per altri 3 minuti. Rimuovere il coperchio, versare la salsa Teriyaki e cospargere il salmone con la salsa per ricoprirlo uniformemente."
+  },
+  "ricette/menrui/bukkake_udon": {
+    "docId": "ricette/menrui/bukkake_udon",
+    "title": "Bukkake Udon",
+    "description": "Udon freddi con condimento versato sopra.",
+    "image": "/img/ricette/bukkake_udon.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "udon",
+      "daikon"
+    ],
+    "recipeIngredient": [
+      "Udon confezionati (quelli freschi vanno benissimo, ma anche quelli secchi andranno bene)",
+      "Un pezzo di 5cm di Daikon",
+      "Cipolline fresche",
+      "Un pezzetto di zenzero fresco",
+      "1 tazza di Dashi freddo",
+      "1 cucchiaio di Mentsuyu",
+      "Un paio di cucchiaini di Salsa di Soia",
+      "Acqua e ghiaccio"
+    ],
+    "instructionsText": "I Condimenti: Per prima cosa prepariamo i topping. Prendiamo il nostro Daikon, lo spelliamo e lo grattugiamo. Strizziamolo leggermente per fargli perdere l'acqua in eccesso e teniamolo da parte. Già che ci siamo, andiamo ad affettare finemente anche qualche cipollina. Lo Zenzero: Dopodiché, peliamo un po' di zenzero con il metodo del cucchiaio (che è infallibile), lo grattugiamo e lo mettiamo da parte. Il Brodo (la parte \"Bukkake\"): \"Sì, ma in tutto questo bukkake che c'entra?\" direte voi. Tranquilli, ci arriveremo. In una ciotola mescoliamo il Dashi, un cucchiaio di Mentsuyu e un paio di cucchiaini di salsa di soia. Cottura degli Udon: Nel frattempo, mettiamo a bollire un pentolino d'acqua e, quando bolle, plop, ci mettiamo dentro i nostri udon preconfezionati. Basterà un paio di minuti di cottura. Raffreddamento: Appena cotti, li scoliamo e li facciamo raffreddare direttamente in una ciotola con acqua e ghiaccio. Poi, mi raccomando, scolateli molto bene."
+  },
+  "ricette/menrui/hiyashi_tori_dashi_somen": {
+    "docId": "ricette/menrui/hiyashi_tori_dashi_somen",
+    "title": "Hiyashi Tori Dashi Somen",
+    "description": "Un piatto di noodles freddi rinfrescante e saporito, con un tocco di aceto che lo rende perfetto per l'estate.",
+    "image": null,
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "kombu",
+      "mirin",
+      "sake",
+      "shiso"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Sbollentare la sovraccoscia di pollo in acqua bollente per un minuto, quindi scolarla e gettare l'acqua. Questo passaggio serve a pulire il pollo e a garantire un brodo più limpido. In una pentola, unire l'alga kombu, il pollo sbollentato, l'acqua, il sakè, la salsa di soia, il mirin e lo zucchero. Portare a leggero bollore. Cuocere a fuoco basso per 25 minuti, schiumando di tanto in tanto le impurità che affiorano in superficie. A metà cottura, dopo circa 12 minuti, girare il pollo. Al termine della cottura, togliere il pollo e l'alga kombu dalla pentola. Lasciare raffreddare il pollo e il brodo separatamente, poi trasferire il brodo in frigorifero per farlo diventare ben freddo. Preparare i condimenti: tagliare il pollo cotto a fettine sottili e condirlo con un pizzico di sale. Tritare finemente il myoga e le foglie di shiso. Cuocere i somen seguendo le istruzioni sulla confezione. Scolarli e passarli immediatamente in una ciotola con acqua fredda e ghiaccio per bloccare la cottura e renderli più sodi. Scolarli di nuovo molto bene. Prendere il brodo freddo dal frigorifero, aggiungere l'aceto e mescolare. Mettere i somen in una ciotola, versarvi sopra il brodo freddo e guarnire con il trito di myoga e shiso, le fettine di pollo e i germogli di ravanello."
+  },
+  "ricette/menrui/natto_soba": {
+    "docId": "ricette/menrui/natto_soba",
+    "title": "Natto Soba",
+    "description": "Spaghetti di grano saraceno freddi con natto, cipolline, alga nori e altre delizie",
+    "image": "/img/ricette/natto_soba.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "katsuobushi",
+      "kizami_nori",
+      "natto",
+      "negi",
+      "nori",
+      "soba"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Bolli i soba in abbondante acqua (io non metto sale), sciacquali sotto l'acqua fredda, trasferiscili in una ciotola con acqua e ghiaccio per raffreddarli, scolali e asciugali bene, e mettili in una ciotola facendo una fossetta al centro, dove metterai il rosso dell'uovo. Aggiungi ai lati il natto, le cipolline tagliate sottili, il katsuobushi, il kizami nori, e il rosso dell'uovo al centro. Opzionale, come in foto, puoi aggiungere un paio di foglie di shiso fresco per guarnire. Mischia il mentsuyu e il dashi, per ottenere lo tsuyu, che verserai al lato della ciotola, per fare un fondo di circa 1 cm di altezza. E ora non ti resta che mangiare! Itadakimasu!"
+  },
+  "ricette/menrui/tori_dashi_no_nyumen": {
+    "docId": "ricette/menrui/tori_dashi_no_nyumen",
+    "title": "Tori dashi no nyūmen",
+    "description": "Somen in brodo di pollo caldo, la versione confortante e super economica di un classico giapponese",
+    "image": "/img/ricette/tori-dashi-nyumen.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [],
+    "recipeIngredient": [],
+    "instructionsText": "Il segreto di questo piatto risiede nella pulizia accurata della materia prima. Iniziamo mettendo le ossa di pollo, preferibilmente spezzate per rilasciare più sapore, in una pentola con un litro e mezzo d'acqua. Portiamo a bollore e lasciamo cuocere per pochi minuti finché non affiorano tutte le impurità in superficie; a questo punto gettiamo l'acqua e sciacquiamo bene le ossa sotto acqua corrente. Rimettiamo le ossa pulite nella pentola con il restante litro e mezzo d'acqua fresca, aggiungendo lo zenzero, lo scarto del porro, la salsa di soia, un pizzico di sale e lo zucchero. Copriamo e lasciamo sobbollire a fiamma bassa per circa un'ora, filtrando poi il brodo ottenuto con un colino a maglie fini per renderlo limpido. Mentre il brodo riposa, cuociamo i somen in acqua bollente per circa 3 minuti. Una volta pronti, è fondamentale scolarli e sciacquarli immediatamente sotto acqua corrente fredda, strofinandoli per rimuovere l'amido, e concludere con un breve bagno in acqua e ghiaccio per fermare la cottura. Per servire, disponiamo i somen in una ciotola, versiamo il brodo di pollo bollente e completiamo con il cipollotto tritato finemente."
+  },
+  "ricette/menrui/tororo_natto_shiso_udon": {
+    "docId": "ricette/menrui/tororo_natto_shiso_udon",
+    "title": "Tororo Natto Shiso Udon",
+    "description": "Una ricetta estiva veloce, nutriente e ricca di consistenze uniche grazie al contrasto tra il cremoso tororo e il natto.",
+    "image": "/img/ricette/tororo-natto-shiso-udon.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "udon",
+      "yamaimo",
+      "natto",
+      "shiso",
+      "negi",
+      "shoyu"
+    ],
+    "recipeIngredient": [
+      "Udon precotti",
+      "1 confezione di Natto",
+      "Yamaimo (igname montano)",
+      "Foglie fresche di Shiso",
+      "Cipollotto (Negi)",
+      "Salsa di soia (Shoyu) di ottima qualità"
+    ],
+    "instructionsText": "Partiamo dal natto: è sempre un'ottima abitudine tenerne una scorta nel freezer. Quando lo prelevate, togliete la pellicola protettiva mentre è ancora congelato per evitare disastri appiccicosi, dopodiché scongelatelo rapidamente utilizzando il microonde. Una volta rinvenuto, conditelo con la sua salsina e la senape fornite nella confezione, e mescolatelo energicamente con le bacchette; più lo girate, più diventerà filante e \"sbavoso\", proprio come deve essere. Mentre l'acqua per la pasta arriva a bollore, occupiamoci del resto dei condimenti. Tritiamo finemente un po' di cipollotto verde e tagliamo a listarelle sottili le profumate foglie di shiso. A questo punto prendiamo il nostro yamaimo e lo sgrattugiamo vigorosamente fino a trasformarlo in tororo: una crema bianca, morbida, \"fluffosa\" e leggermente gelatinosa. Immergiamo gli udon nell'acqua bollente per un paio di minuti, giusto il tempo necessario affinché i noodles si separino e si ammorbidiscano. Li scoliamo e li laviamo accuratamente sotto l'acqua corrente, tuffandoli immediatamente in una ciotola di acqua e ghiaccio. Questo shock termico è vitale per fermare la cottura e ottenere una consistenza soda, elastica e perfettamente ghiacciata. Diamo un'ultima scolata rigorosa per non annacquare il piatto. È arrivato il momento dell'assemblaggio, la parte più divertente. In una bella ciotola capiente, posizioniamo gli udon ghiacciati sul fondo. Copriamo i noodles con una generosa cascata di tororo cremoso, adagiamo il natto filante al centro e circondiamo il tutto con lo shiso tritato. Facciamo cadere qualche goccia di salsa di soia di ottima qualità per dare la giusta sapidità, e concludiamo l'opera con il cipollotto."
+  },
+  "ricette/menrui/udon_burro_e_shoyu": {
+    "docId": "ricette/menrui/udon_burro_e_shoyu",
+    "title": "Udon con Burro e Salsa di Soia",
+    "description": "Il comfort food perfetto, l'equivalente giapponese del nostro \"burro e parmigiano\".",
+    "image": "/img/ricette/udon_burro_e_shoyu.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "udon",
+      "katsuobushi",
+      "kizami_nori",
+      "nori"
+    ],
+    "recipeIngredient": [
+      "1 confezione di Udon precotti",
+      "Una noce di Burro",
+      "1 cucchiaio di Salsa di Soia",
+      "Katsuobushi in abbondanza",
+      "Kizami Nori (alga nori a striscioline) per guarnire"
+    ],
+    "instructionsText": "Cuocere gli udon in abbondante acqua bollente per circa due minuti, o seguendo le istruzioni riportate sulla confezione. Scolare gli udon e trasferirli direttamente in una padella calda. Aggiungere subito la noce di burro e il cucchiaio di salsa di soia. Mantecare a fuoco vivo per circa un minuto, saltando gli udon come si farebbe con la pasta, finché il condimento non si sarà amalgamato creando una salsa cremosa. Impiattare immediatamente. Cospargere con abbondante katsuobushi (usandolo proprio come se fosse parmigiano) e guarnire con una manciata di kizami nori. È una soddisfazione unica, con un rapporto bontà-fatica imbattibile. Itadakimasu!"
+  },
+  "ricette/menrui/yaki_udon": {
+    "docId": "ricette/menrui/yaki_udon",
+    "title": "Yaki Udon",
+    "description": "Un piatto giapponese completo, economico e velocissimo da preparare, nato per caso nel dopoguerra.",
+    "image": "/img/ricette/yaki_udon.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "shoyu",
+      "mirin",
+      "katsuobushi",
+      "beni_shoga"
+    ],
+    "recipeIngredient": [
+      "Udon precotti",
+      "80g di fettine di maiale (preferibilmente una parte grassa; i vegetariani possono sostituirlo con dei funghi shiitake)",
+      "1 cipolla",
+      "150g di cavolo cappuccio",
+      "1/2 carota",
+      "Salsa di soia (Shoyu) 1 cucchiaio",
+      "Mirin 1 cucchiaio",
+      "Dashi in polvere 1 cucchiaino",
+      "Katsuobushi per guarnire",
+      "Beni Shoga (zenzero rosso) per guarnire",
+      "Olio di semi per la cottura"
+    ],
+    "instructionsText": "Iniziamo la preparazione tagliando le verdure che formeranno la base del piatto. Tagliamo la carota a listarelle sottili e il cavolo cappuccio a pezzi grossolani. Un trucco importante riguarda la cipolla: va tagliata rigorosamente per il lungo; in questo modo manterrà la sua struttura e non si sfalderà durante la cottura. Tagliamo anche la fettina di carne di maiale a piccoli quadrotti. A parte, prepariamo una salsa mescolando in una ciotolina la salsa di soia, il mirin e il dashi in polvere. Questa e' una versione super semplificata della classica salsa per yakisoba, ma è perfetta per esaltare il sapore degli udon senza sovrastarli. Se volete fare la salda per yakisoba, trovate la ricetta completa qui. Scaldiamo bene una padella capiente (o un wok) con un cucchiaino di olio di semi e iniziamo rosolando i pezzetti di maiale. Una volta che la carne si e' dorata, inseriamo la cipolla, seguita dal cavolo cappuccio e dalle carote, saltando il tutto a fiamma vivace per farle ammorbidire ma preservandone la croccantezza. A questo punto, tuffiamo in padella i nostri udon e versiamo la salsa preparata precedentemente. Diamo una bella mescolata vigorosa saltando la pasta per distribuire i sapori in modo uniforme. Trasferiamo i nostri Yaki Udon ancora fumanti su un piatto da portata e arricchiamo il tutto con l'immancabile katsuobushi, che danzerà con il calore, e un tocco di beni shoga, lo zenzero rosso che aggiunge il perfetto contrasto acido. In soli 10 minuti e con pochissimi ingredienti, avrete portato in tavola l'autentico sapore del Giappone."
+  },
+  "ricette/menrui/yakisoba": {
+    "docId": "ricette/menrui/yakisoba",
+    "title": "Yakisoba",
+    "description": "La pasta saltata alla giapponese",
+    "image": "/img/ricette/yakisoba.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "aonori",
+      "katsuobushi",
+      "shiitake"
+    ],
+    "recipeIngredient": [
+      "Pasta precotta a temperatura ambiente (ramen noodles o altra pasta)",
+      "Salsa yakisoba circa 3-4 cucchiai",
+      "Cipolla",
+      "Cavolo cappuccio",
+      "Benishoga",
+      "Pancetta (opzionale)",
+      "Funghi shiitake (opzionale)",
+      "Aonori",
+      "Katsuobushi"
+    ],
+    "instructionsText": "Preparare la pasta qualche ora prima, facendola super al dente (gli date giusto una sbollentata), scolate e sciaquatela bene sotto l'acqua fredda, scolatela di nuovo e conditela con un filo d'olio per evitare che si attacchi. Lasciatela a temperatura ambiente fino al momento di usarla. Potete metterla in un sacchetto di plastica ben chiuso, in modo che non si secchi, o in un contenitore ermetico. Taglia la cipolla a fette sottili, il cavolo cappuccio a quadratini, i funghi shiitake a fettine e la pancetta a striscioline. In una padella capiente o wok, scalda un po' d'olio e metti la panctta a rosolare. Quando inizia a rilasciare il grasso, aggiungi la cipolla, cuocendo fino a quando diventa trasparente. Aggiungi il cavolo cappuccio e i funghi shiitake, cuocendo fino a quando il cavolo inizia ad appassire. Aggiungi la pasta e mescola bene per amalgamare gli ingredienti. Versa la salsa yakisoba, dai una bella mescolata e cuoci per qualche minuto senza mescolare, in modo che la pasta faccia tutta una crosticina croccante. All'ultimo aggiungi il benishoga, mescola e servi con una spolverata di aonori e katsuobushi."
+  },
+  "ricette/menrui/zaru_soba": {
+    "docId": "ricette/menrui/zaru_soba",
+    "title": "Zaru Soba",
+    "description": "Spaghetti di grano saraceno freddi",
+    "image": "/img/ricette/zaru_soba.jpg",
+    "recipeCategory": "Noodles",
+    "recipeKeywords": [
+      "daikon",
+      "kizami_nori",
+      "nori"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Bollire gli spaghetti in abbondante acqua senza sale per la durata suggerita sulla confezione. Scolarli conservando una tazza dell'acqua di cottura (sobayu). Usare un colino e sciacquarli sotto acqua corrente fredda con le mani per eliminare l'amido in eccesso. Trasferirli in una ciotola con acqua e ghiaccio per raffreddarli per circa 30 secondi, poi scolarli bene e metterli da parte."
+  },
+  "ricette/nimono/daikon_no_nimono": {
+    "docId": "ricette/nimono/daikon_no_nimono",
+    "title": "Daikon no Nimono",
+    "description": "Una ricetta gourmet per preparare il daikon stufato, rendendolo tenero, dolce e ricco di umami.",
+    "image": "/img/ricette/daikon_no_nimono.jpg",
+    "recipeCategory": "Stufati",
+    "recipeKeywords": [
+      "daikon",
+      "nimono",
+      "verdure",
+      "stufati",
+      "vegan",
+      "vegetarian"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Per iniziare, prendete un grosso daikon e privatelo delle estremità. Anche se la buccia può sembrare sottile, lo strato esterno è in realtà piuttosto coriaceo, quindi è fondamentale rimuoverlo interamente utilizzando la tecnica del katsuramuki, effettuando un taglio rotatorio con il coltello. Una volta pelato, tagliate il tubero in fette spesse circa 3-4 cm. Per evitare che le fette si sfaldino durante la lunga cottura, rifilate accuratamente gli spigoli di ogni disco seguendo la tecnica del mentori. Per favorire la penetrazione del calore e degli aromi, incidete una croce profonda un paio di centimetri su una delle basi di ogni fetta di daikon. Passate quindi alla fase di pre-cottura: mettete il daikon in una pentola e copritelo con l'acqua recuperata dal lavaggio del riso. Coprite con un otoshibuta e fate bollire per circa un'ora; l'amido contenuto nell'acqua del riso aiuterà a rimuovere l'amaro naturale della radice, rendendola dolcissima. Verificate la cottura con uno stuzzicandente: quando penetra la polpa senza resistenza, scolate il daikon e lavatelo delicatamente sotto acqua corrente. Rimettetelo sul fuoco coprendolo con acqua fresca, portate a bollore e sciacquatelo nuovamente. Questa doppia pulizia assicura un sapore pulito e delicato. Per la cottura finale, disponete le fette in una pentola e ricopritele interamente con del dashi. Aggiungete un cucchiaio di mirin e un paio di cucchiai di salsa di soia (shoyu). Posizionate nuovamente l'otoshibuta e lasciate sobbollire a fuoco dolce per circa mezz'ora. Al termine, spegnete la fiamma e lasciate riposare il daikon nel suo brodo fino a quando non si sarà raffreddato; questo passaggio è fondamentale affinché la radice assorba tutto l'umami del liquido. Mentre il daikon riposa, preparate il guarnimento affettando molto finemente della scorza di limone, avendo cura di prelevare solo la parte gialla. Potete servire il piatto sia freddo che caldo, accompagnandolo con il suo brodo di cottura e completando con le striscioline di limone. Se eseguito correttamente, il daikon risulterà così tenero da poter essere tagliato facilmente con le bacchette."
+  },
+  "ricette/nimono/kabocha_no_nimono": {
+    "docId": "ricette/nimono/kabocha_no_nimono",
+    "title": "Kabocha no Nimono",
+    "description": "La zucca giapponese stufata, un classico contorno autunnale vegano",
+    "image": "/img/ricette/kabocha_no_nimono.jpg",
+    "recipeCategory": "Stufati",
+    "recipeKeywords": [
+      "vegan",
+      "mirin",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "Zucca (varietà Kabocha o Mantovana)",
+      "Dashi (o Dashi Vegano) q.b.",
+      "Salsa di soia (Shoyu)",
+      "Mirin",
+      "Sake",
+      "Zucchero (opzionale)"
+    ],
+    "instructionsText": "Per questa ricetta l'ideale è utilizzare la zucca Mantovana, che è un sostituto perfetto per le zucche giapponesi, ed è facilmente reperibile. Iniziamo tagliando la zucca a pezzetti più o meno uguali, cercando di mantenere la buccia che in cottura diventerà tenera ed aiuterà i pezzi a non sfaldarsi. Prendiamo una pentola e disponiamo i pezzi di zucca sul fondo creando un vero e proprio mosaico, con la buccia preferibilmente rivolta verso l'alto o il basso in modo ordinato, cercando di non sovrapporli troppo. Copriamo il tutto con il dashi (usando il dashi vegano per mantenere la ricetta 100% vegetale) fino a coprire appena la zucca, e accendiamo il fuoco. Appena il liquido raggiunge il bollore, abbassiamo la fiamma al minimo e procediamo con il condimento. Aggiungiamo un paio di cucchiai di salsa di soia, un paio di mirin e un paio di sake, regolando le quantità in base a quanta zucca state cucinando. Se volete un sapore più dolce e glassato, potete aggiungere anche un cucchiaio di zucchero in questa fase. A questo punto copriamo con un otoshibuta, il tipico coperchio più piccolo della pentola che poggia direttamente sugli alimenti. Questo strumento è fondamentale nei nimono perché permette di usare meno brodo, diffonde il calore uniformemente e tiene fermi gli ingredienti evitando che si rompano col bollore. Se non lo avete, potete realizzarlo facilmente con un foglio di carta forno ritagliato a misura e bucato al centro. Lasciamo stufare per circa 10 minuti. Per verificare la cottura, facciamo la prova con uno stuzzicadenti: se entra facilmente nella polpa, la zucca è pronta."
+  },
+  "ricette/nimono/kakuni": {
+    "docId": "ricette/nimono/kakuni",
+    "title": "Buta Kaku-ni",
+    "description": "Pancia di maiale cotta lentamente in salsa di soia",
+    "image": "/img/ricette/kakuni.jpg",
+    "recipeCategory": "Stufati",
+    "recipeKeywords": [
+      "daikon",
+      "kombu",
+      "mirin",
+      "negi",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "1 kg di pancetta di maiale",
+      "1 Cipolla verde o un negi",
+      "1 pezzo di zenzero",
+      "1/2 tazza di salsa di soia",
+      "1/2 tazza di mirin",
+      "1/4 tazza di zucchero",
+      "1/4 tazza di sake",
+      "1 pezzo di alga kombu",
+      "4 uova"
+    ],
+    "instructionsText": ""
+  },
+  "ricette/nimono/nikujaga": {
+    "docId": "ricette/nimono/nikujaga",
+    "title": "Nikujaga",
+    "description": "Carne e patate, il comfort food per eccellenza della cucina casalinga giapponese",
+    "image": "/img/ricette/nikujaga.jpg",
+    "recipeCategory": "Stufati",
+    "recipeKeywords": [
+      "mirin"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "La preparazione inizia con il taglio delle verdure, che in questo piatto deve essere piuttosto rustico ma curato. Tagliamo la carota e la cipolla a pezzettoni grossolani. La carne di manzo deve essere tagliata a straccetti o fettine sottili, ideali per una cottura in umido veloce che la mantenga morbida. Passiamo alle patate: dopo averle tagliate a pezzi grandi, è fondamentale eseguire il mentori. Con un pelapatate, rifiliamo tutti gli spigoli vivi di ogni pezzo di patata, smussandoli. Questa tecnica serve a evitare che la patata si sfaldi e si rompa durante la cottura nel liquido, mantenendo il brodo limpido e i pezzi integri. Per la cottura, l'ordine di inserimento degli ingredienti è importante. Scaldiamo un filo di olio di semi in una pentola capiente (o un tegame di ghisa) e inseriamo prima le patate, poi le cipolle. Rosoliamo le verdure insieme per qualche minuto per insaporirle. Solo a questo punto aggiungiamo la carne. Non cerchiamo una rosolatura aggressiva della carne, ma vogliamo cuocerla dolcemente affinché si sfaldi e diventi tenerissima in cottura. Una volta che la carne ha cambiato colore, uniamo le carote e copriamo tutto a filo con il dashi. Alziamo la fiamma al massimo e portiamo a bollore. Appena il liquido bolle, utilizziamo un colino a maglia fine per \"schiumare\" il brodo, rimuovendo tutte le impurità che affiorano in superficie. A questo punto condiamo aggiungendo un giro di mirin e di salsa di soia. Abbassiamo la fiamma al minimo e copriamo con un otoshibuta. Lasciamo cuocere dolcemente per circa 15 minuti. Trascorso questo tempo, spegniamo il fuoco e lasciamo riposare: è in questa fase che i sapori si amalgamano e le verdure assorbono il condimento. Mentre il Nikujaga riposa, possiamo sbollentare brevemente delle taccole in acqua salata: useremo il loro verde brillante come guarnizione decorativa per dare un tocco di colore al piatto finito."
+  },
+  "ricette/preparazioni_di_base/brodi/dashi": {
+    "docId": "ricette/preparazioni_di_base/brodi/dashi",
+    "title": "Dashi",
+    "description": "il brodo base per moltissime ricette",
+    "image": "/img/ricette/dashi.jpg",
+    "recipeCategory": "Brodi",
+    "recipeKeywords": [
+      "katsuobushi",
+      "kombu"
+    ],
+    "recipeIngredient": [
+      "1.8 litri di acqua fredda",
+      "30 grammi di alga kombu",
+      "35 grammi di katsuobushi"
+    ],
+    "instructionsText": "Non togliere la polvere bianca dall'alga Kombu: quello è il glutammato naturalmente presente nell'alga, fonte di umami, ed è esattamente il motivo per cui usiamo la kombu. Versare l'acqua in una pentola, mettere l'alga kombu a bagno e lasciar riposare per almeno 1 ora (l'alga kombu deve reidratarsi completamente) Coprire con un coperchio e portare a 70 gradi a fiamma bassa (più ci mette, meglio è). Conviene usare un termometro, quando l’acqua raggiunge la temperatura spegnere la fiamma, e lasciare in infusione per altri 20 minuti. Togliere l’alga kombu, rialzare la fiamma e portare a 90 gradi, ed eliminare la schiuma con una schiumarola a setaccio fino. Spegnare la fiamma, e mettere il katsuobushi. Tenere il katsuobushi da 10-15 secondi per un dashi piu delicato, fino a 20-30 minuti per un dashi piu intenso. Togliere il katsuobushi e, e filtrare il brodo ottenuto con un panno fino. Complimenti avete appena fatto il dashi!"
+  },
+  "ricette/preparazioni_di_base/brodi/mentsuyu": {
+    "docId": "ricette/preparazioni_di_base/brodi/mentsuyu",
+    "title": "Mentsuyu",
+    "description": "Il brodo per immergere soba e udon",
+    "image": "/img/ricette/mentsuyu.jpg",
+    "recipeCategory": "Brodi",
+    "recipeKeywords": [
+      "katsuobushi",
+      "kombu",
+      "mirin",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "½ tazza di sake",
+      "1 tazza abbondante di mirin (dice 1 ⅛ che dovrebbe essere 1 + 2 cucchiai)",
+      "1 tazza di salsa di soia",
+      "1 pezzo di kombu (5 grammi? pesare)",
+      "1 tazza di katsuobushi (pesare)"
+    ],
+    "instructionsText": "Metti tutto in un pentolino e porta molto dolcemente a ebollizione, poi spegni il fuoco e lascia freddare Filtra tutto e metti in un barattolo, la salsa inizia a dare il meglio di se dopo 2-3 giorni in frigorifero. Non so ancora quanto si conservi a lungo, ne ho una di 2 mesi, sembra buona e non sono ancora morto."
+  },
+  "ricette/preparazioni_di_base/brodi/vegan_dashi": {
+    "docId": "ricette/preparazioni_di_base/brodi/vegan_dashi",
+    "title": "Dashi Vegano",
+    "description": "La base fondamentale della cucina giapponese in versione vegana. Un brodo ricco di umami preparato con alga kombu e funghi shiitake.",
+    "image": null,
+    "recipeCategory": "Brodi",
+    "recipeKeywords": [
+      "dashi",
+      "vegan",
+      "kombu",
+      "shiitake"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "La preparazione richiede tempo e pazienza per estrarre al meglio i sapori in modo delicato (infusione a freddo)."
+  },
+  "ricette/preparazioni_di_base/condimenti/furikake": {
+    "docId": "ricette/preparazioni_di_base/condimenti/furikake",
+    "title": "Furikake",
+    "description": "Condimento secco per riso",
+    "image": "/img/ricette/furikake.jpg",
+    "recipeCategory": "Condimenti",
+    "recipeKeywords": [
+      "katsuobushi",
+      "kombu",
+      "nori",
+      "sesamo"
+    ],
+    "recipeIngredient": [
+      "Katsuobushi",
+      "Alga Kombu (anche recuperati dal dashi)",
+      "Semi di Sesamo",
+      "Alga nori"
+    ],
+    "instructionsText": "Se il Katsuobushi e' nuovo, prendetene una bella manciata e tostatelo in padella, come si fa col sesamo (ovvero a fuoco medio, senza coperchio, muovendolo spesso e togliendolo quando inizia a imbrunire) Se invece e' usato, strizzatelo benissimo, e cercate di sfilacciarlo il piu' possibile prima di metterlo in padella. Poi mettetelo in una padella bella ampia, in modo che non tenda ad appallottolarsi, e fare come sopra, ma con molto piu' tempo ed attenzione. Quando il Katsuobushi e' bello tostato, sbriciolatelo senza pieta' (si ma fate pezzetti, non sabbia...) L'alga kombu, se e' nuova ed essiccata, mettetela a bagno un po' per ammorbidirla, senno' finisce che ci rompete il coltello. E poi, nuova o usata che sia, fatela a quadratini di mezzo centimetro di lato. Tostate i semi di sesamo (come se fosse Katsuobushi), senza distrarvi e a fuoco medio-basso, perche' come vi distraete si carbonizzano immediatamente. Sbriciolate l'alga nori con le mani, da molta soddisfazione. Anche qui attenti a non fare l'Aonori per sbaglio. Comunque, siccome la kombu, cosi come e', e' dura da morire, mettetela in una padella, e metteteci tutto il condimento. Fate andare a fuoco basso, finche' il liquido non si sara' ritirato, e l'alga kombu ammorbidita. Se l'alga kombu e' ancora dura, aggiungete un po' di acqua e fate andare ancora. Quando il liquido avra' raggiunto la densita' della salsa Teriyaki quando e' pronta (ho imparato da mia madre a dare sempre istruzioni utilissime), spegnete il fuoco e aggiungete il katsuobushi, i semi di sesamo e l'alga nori, e mescolate bene. Alla fine vengono tutte palline ammappazzate ma non vi preccupate. Mettete tutto in forno su un bel foglio di carta da forno, a bassa temperatura (70-75 gradi), e ogni tanto aprite il forno, mescolate, sfragnate, e richiudete, finche' non sara' tutto bello secco e croccante. A questo punto dategli un'ultima sfragnata e mettete in un barattolo, e ciaone dal Giappone."
+  },
+  "ricette/preparazioni_di_base/salse/nikiri": {
+    "docId": "ricette/preparazioni_di_base/salse/nikiri",
+    "title": "Nikiri Sauce",
+    "description": "Salsa densa da spennellare sui nigiri",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "mirin",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "1 tazza e 1/2 di salsa di soia",
+      "1 tazza di mirin",
+      "1/2 tazza di sake",
+      "1/2 tazza di dashi"
+    ],
+    "instructionsText": "Metti il mirin e il sake in un pentolino a scaldare, e fai evaporare tutto l'alcol. Aggiungi la salsa di soia e il dashi, e fai sobbollire a fuoco basso fino a ridurre della metà il volume. Fai raffreddare e metti in frigo."
+  },
+  "ricette/preparazioni_di_base/salse/okonomiyaki": {
+    "docId": "ricette/preparazioni_di_base/salse/okonomiyaki",
+    "title": "Salsa Okonomiyaki",
+    "description": "Salsa per gli okonomiyaki",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "rice"
+    ],
+    "recipeIngredient": [
+      "3 cucchiai di ketchup",
+      "2 cucchiai di salsa Worcestershire",
+      "2 cucchiai di salsa di ostriche (oyster sauce)",
+      "1 cucchiaio di zucchero (oppure miele, per un gusto più morbido)",
+      "1 cucchiaio di salsa di soia (shoyu), meglio se koikuchi (scura e saporita)",
+      "1 cucchiaino di aceto di mele o aceto di riso (opzionale, se preferisci un tocco acidulo)"
+    ],
+    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di ostriche. Aiutati con una piccola frusta per amalgamare bene il composto. Aggiungi lo zucchero (o il miele) e gira finché si scioglie del tutto, dando alla salsa la dolcezza tipica per l’okonomiyaki. Versa la salsa di soia e, se desideri una punta di acidità in più, un cucchiaino di aceto (di mele o di riso). Continua a mescolare finché il tutto non risulta ben omogeneo. Prova la salsa e, se occorre, aggiungi un pizzico di zucchero o qualche goccia di soia in più, per bilanciare dolce, salato e acidulo secondo il tuo gusto."
+  },
+  "ricette/preparazioni_di_base/salse/ponzu": {
+    "docId": "ricette/preparazioni_di_base/salse/ponzu",
+    "title": "Salsa Ponzu",
+    "description": "Salsa fresca ed agrumata",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "mirin",
+      "rice",
+      "yuzu"
+    ],
+    "recipeIngredient": [
+      "2 parti di salsa di soia",
+      "1 parte e ½ di dashi",
+      "1 parte di succo di yuzu (si può sostituire con il limone o il lime, secondo i gusti)",
+      "½ parte di aceto di riso",
+      "1 parte di mirin"
+    ],
+    "instructionsText": "Mescolare a freddo in una ciotolina, e lasciare riposare in frigo per almeno 30 minuti prima di servire. Si conserva per un sacco di tempo, non sono mai riuscito a farla andare a male!"
+  },
+  "ricette/preparazioni_di_base/salse/takoyaki": {
+    "docId": "ricette/preparazioni_di_base/salse/takoyaki",
+    "title": "Salsa Takoyaki",
+    "description": "Salsa per i takoyaki",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [],
+    "recipeIngredient": [
+      "3 cucchiai di salsa worcestershire",
+      "1 cucchiaio di mentsuyu",
+      "¾ cucchiaio di zucchero",
+      "½ cucchiaio di ketchup"
+    ],
+    "instructionsText": "Mescolare a freddo - e regolare lo zucchero in base alla dolcezza del ketchup"
+  },
+  "ricette/preparazioni_di_base/salse/tentsuyu": {
+    "docId": "ricette/preparazioni_di_base/salse/tentsuyu",
+    "title": "Salsa Tentsuyu: ricetta per tempura",
+    "description": "Ricetta della salsa tentsuyu, il condimento giapponese per il tempura a base di dashi, mirin e salsa di soia. Ingredienti, dosi e preparazione.",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "daikon",
+      "mirin"
+    ],
+    "recipeIngredient": [
+      "3 parti dashi",
+      "1 parte mirin",
+      "1 parte salsa di soia",
+      "Daikon grattugiato"
+    ],
+    "instructionsText": "Versare tutti gli ingredienti in un pentolino, e scaldare fino a sobbollire (se c'e' lo zucchero, controllare che sia completamente dissolto), far freddare e conservare in un barattolo in frigorifero (2-3 settimane max) Quando si serve, mischiare con daikon grattugiato"
+  },
+  "ricette/preparazioni_di_base/salse/teriyaki": {
+    "docId": "ricette/preparazioni_di_base/salse/teriyaki",
+    "title": "Salsa Teriyaki",
+    "description": "La salsa barbecue giapponese",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "mirin",
+      "potato_starch",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "1 parte di sake",
+      "1 parte di mirin",
+      "1 parte di salsa di soia",
+      "½ parte di zucchero (opzionale, o anche meno)",
+      "fecola di patate o amido di mais (maizena) q.b."
+    ],
+    "instructionsText": "In un piccolo tegame, riscaldare il sake e il mirin fino al lieve bollore. Utilizzando un accendino con punta lunga, incendiare l'alcool in eccesso. Successivamente, incorporare la salsa di soia e lo zucchero, mescolando a fuoco bassissimo fino a ottenere un leggero sobbollimento. Questo processo conferisce alla salsa di soia una nota più profonda e favorisce una leggera caramellizzazione. È possibile arricchire il sapore aggiungendo la parte verde dei porri, fettine di zenzero o aglio tritato, a seconda delle preferenze o del piatto a cui è destinata. Io continuo la cottura fino a che non si riduce di circa la metà del suo volume, ma potete proseguire fino a raggiungere l'intensità di sapore desiderata. A parte, diluire la fecola di patate in un po' d'acqua fredda, poi versarla nel tegame, mescolando accuratamente, e lasciar sobbollire per altri 5 minuti. La salsa si addensa e diventa liscia e lucida."
+  },
+  "ricette/preparazioni_di_base/salse/tonkatsu": {
+    "docId": "ricette/preparazioni_di_base/salse/tonkatsu",
+    "title": "Salsa Tonkatsu",
+    "description": "",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [],
+    "recipeIngredient": [
+      "4 cucchiai di ketchup (preferibilmente uno dal sapore poco zuccherino)",
+      "4 cucchiai di salsa Worcestershire (in Giappone si usa una salsa simile, più fruttata, ma la Worcestershire classica è un’ottima alternativa)",
+      "1 cucchiaio di salsa di soia (shoyu), meglio se koikuchi (scura e saporita)",
+      "1 cucchiaio di zucchero (o 1 cucchiaio di mirin per un tocco più giapponese)",
+      "1 cucchiaino di senape giapponese (karashi) o, in mancanza, di senape delicata/dijon",
+      "1 cucchiaio di aceto di mele (opzionale, se desideri una nota più acidula)"
+    ],
+    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di soia. Aggiungi lo zucchero (o il mirin) e mescola con una piccola frusta o un cucchiaio fino a farlo sciogliere completamente. Se preferisci un tocco più delicato, usa il mirin al posto dello zucchero. Incorpora il cucchiaino di senape (karashi o dijon) e, se gradisci una punta di acidità in più, un cucchiaio di aceto di mele. Continua a mescolare finché il composto non risulta omogeneo. Prova la salsa e, se necessario, modifica il bilanciamento dolce-salato-agro, regolando con un pizzico di zucchero o qualche goccia in più di salsa di soia."
+  },
+  "ricette/preparazioni_di_base/salse/yakisoba_sauce": {
+    "docId": "ricette/preparazioni_di_base/salse/yakisoba_sauce",
+    "title": "Salsa Yakisoba",
+    "description": "La salsa agrodolce e umami indispensabile per preparare gli yakisoba fatti in casa.",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [],
+    "recipeIngredient": [
+      "2 cucchiai di Zucchero",
+      "2 cucchiai di Ketchup",
+      "3 cucchiai di Salsa di ostriche",
+      "1 cucchiaio e mezzo di Salsa di soia",
+      "4 cucchiai di Salsa worcestershire"
+    ],
+    "instructionsText": "In una ciotola, versare per primo lo zucchero. Questo è il passaggio più importante per assicurarsi che si sciolga bene. Aggiungere le salse procedendo dalla più densa alla più liquida per facilitare la miscelazione. Iniziare quindi con il ketchup, seguito dalla salsa di ostriche. Versare infine la salsa di soia e la salsa worcestershire. Mescolare energicamente con un cucchiaio o una piccola frusta finché lo zucchero non sarà completamente disciolto e la salsa non risulterà omogenea. La salsa è pronta per essere usata, ma il giorno dopo sarà ancora meglio, quando i sapori si saranno amalgamati. Si conserva in frigorifero per una settimana circa."
+  },
+  "ricette/preparazioni_di_base/salse/yakitori": {
+    "docId": "ricette/preparazioni_di_base/salse/yakitori",
+    "title": "Yakitori Tare",
+    "description": "Salsa per yakitori",
+    "image": null,
+    "recipeCategory": "Salse",
+    "recipeKeywords": [
+      "mirin",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "1 tazza di salsa di soia",
+      "1  tazza di mirin",
+      "½ tazza di sake",
+      "½ tazza di acqua",
+      "2 cucchiai di zucchero di canna (dice 4 o addirittura ½ tazza)",
+      "Parte verde delle cipolline o porro",
+      "Opzionale - zenzero e aglio grattugiati"
+    ],
+    "instructionsText": "Bollire al minimo fino a ridurre della metà il volume."
+  },
+  "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar": {
+    "docId": "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar",
+    "title": "Sushisu",
+    "description": "Il condimento per il riso per il sushi",
+    "image": null,
+    "recipeCategory": "Sushi",
+    "recipeKeywords": [],
+    "recipeIngredient": [],
+    "instructionsText": "Sciogliere completamente lo zucchero e il sale nell'aceto, aggiungere l'alga e lasciare riposare per 24 ore in frigorifero. Dopo 24 ore, filtrare e imbottigliare, ed e' pronto per l'uso."
+  },
+  "ricette/riso/gyudon": {
+    "docId": "ricette/riso/gyudon",
+    "title": "Gyudon",
+    "description": "La ciotola di riso con carne di manzo e cipolla",
+    "image": "/img/ricette/gyudon.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "beni_shoga",
+      "mirin",
+      "rice",
+      "sake"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Taglia la cipolla a fettine sottili per il lungo, e la cipollina verde a rondelle sottili. In una padella mmetti il dashi, la salsa di soia, il mirin e il sake e le cipolle, fai cuocere a fuoco medio fino a che le cipolle non si ammorbidiscono. Usa un coperchio per non far evaporare il brodo. Dopo 2-3 minuti aggiungi la carne e fai cuocere finche' la carne non e' piu' rosa. Quando la carne e' cotta, spegni il fuoco e aggiungi la cipollina verde. Versa il tutto sopra il riso caldo e guarnisci con beni shoga."
+  },
+  "ricette/riso/hamburger_don": {
+    "docId": "ricette/riso/hamburger_don",
+    "title": "Hamburger Don",
+    "description": "Una ciotola di riso (donburi) facile e veloce con carne macinata e uova.",
+    "image": "/img/ricette/hamburger_don.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "rice"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Tritare finemente la cipolla. Scaldare l'olio di semi in una padella a fuoco medio. Aggiungere la cipolla e soffriggere finché non appassisce. Aggiungere la carne macinata mista, condire con sale e pepe. Continuare a cuocere, premendo la carne per rosolarla e sgranarla, finché non è ben cotta. Aggiungere il ketchup e la salsa Worcestershire e saltare per 1-2 minuti finché il liquido in eccesso non evapora. Creare tre incavi nel composto di carne. Rompere un uovo in ciascun incavo. Abbassare la fiamma e cuocere per circa 5 minuti, o finché le uova non raggiungono la cottura desiderata. Mettere il riso caldo nelle ciotole individuali e adagiarvi sopra il composto di carne e uova."
+  },
+  "ricette/riso/nira_shio_kombu_onigiri": {
+    "docId": "ricette/riso/nira_shio_kombu_onigiri",
+    "title": "Nira shio kombu no maze onigiri",
+    "description": "Un onigiri ricco di umami, preparato mescolando il riso caldo con erba aglina, shio kombu, katsuobushi e olio di sesamo.",
+    "image": "/img/ricette/nira_shio_kombu_onigiri.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "rice",
+      "sesamo",
+      "sesame_oil",
+      "kombu",
+      "katsuobushi",
+      "nori"
+    ],
+    "recipeIngredient": [
+      "Riso bianco (ben caldo)",
+      "Nira (erba aglina)",
+      "Sesamo",
+      "Olio di sesamo",
+      "Shio kombu (striscioline di alga kombu salata)",
+      "Katsuobushi",
+      "Alga Nori",
+      "Sale q.b."
+    ],
+    "instructionsText": "Iniziamo tritando finemente l'erba aglina (nira) al coltello. In una ciotola capiente, disponiamo il riso cotto, che per questa preparazione deve essere rigorosamente ben caldo. Aggiungiamo in grande abbondanza la nira, il sesamo, un bel giro di olio di sesamo, lo shio kombu e il katsuobushi. Con l'aiuto di una spatola, mischiamo bene tutto il composto. Passiamo ora alla formatura delle nostre magiche polpette di riso giapponesi. È fondamentale avere le mani bagnate e ben salate per evitare che il riso si attacchi e per dare sapidità all'esterno. L'arte dell'onigiri sta nell'appallottolare e \"striangolare\" il composto con delicatezza: non dobbiamo fare una palla appiccicosa, ma dobbiamo assicurarci di mantenerlo arioso e \"fluffoso\" all'interno. Per aiutare gli onigiri a mantenere perfettamente la forma, è consentito e suggerito avvilupparli strettamente nella pellicola da cucina. Li lasciamo riposare così finché non si potranno raffreddare e solidificare a dovere. Il tocco finale è l'alga. Prendiamo un foglio di alga nori e, prestando attenzione, lo passiamo direttamente sopra la fiamma viva del fornello per averla bella croccante. Liberiamo gli onigiri dalla pellicola, li avvolgiamo nella nori appena tostata e la magia è servita."
+  },
+  "ricette/riso/onigiri": {
+    "docId": "ricette/riso/onigiri",
+    "title": "Onigiri al Tonno e Maionese",
+    "description": "Il classico snack giapponese per una merenda veloce o un pranzo al sacco.",
+    "image": null,
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "nori",
+      "rice"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Sciacqua il riso sotto acqua fredda fino a che l'acqua non risulta limpida. Cuoci il riso con la quantità di acqua indicata, utilizzando una pentola con coperchio o una cuociriso. Una volta cotto, lascia riposare coperto per 10 minuti. Mentre il riso cuoce, prepariamo il ripieno. Scola il tonno molto accuratamente. In una ciotola, mescola il tonno con la maionese fino a ottenere un composto omogeneo e cremoso, ma non eccessivamente liquido. Puoi aggiungere un pizzico di pepe nero o meglio ancora di shichimi togarashi). Tieni una piccola ciotola d'acqua con un pizzico di sale. Bagna le mani con l'acqua salata: questo aiuterà a non far attaccare il riso e a condire l'esterno dell'onigiri. Prendi una porzione di riso cotto, grande piu o meno come una palla da tennis, e appiattiscila nel palmo della mano, creando una conca al centro. Metti un cucchiaio abbondante di ripieno di tonno e maionese nella conca. Copri il ripieno con il riso circostante e sigillalo completamente, poi modella il tutto con entrambe le mani nella classica forma triangolare, premendo delicatamente per compattare. Taglia i fogli di alga nori a strisce (circa 3-4 cm di larghezza). Avvolgi una striscia alla base dell'onigiri, lasciando le estremità rivolte verso l'esterno, per creare un pratico punto in cui afferrare lo snack senza toccare il riso."
+  },
+  "ricette/riso/onigiri_kimchi_asiago": {
+    "docId": "ricette/riso/onigiri_kimchi_asiago",
+    "title": "Onigiri Kimchi e Asiago",
+    "description": "Una golosa contaminazione nippo-coreana-italiana per un onigiri croccante e saporitissimo.",
+    "image": "/img/ricette/onigiri_kimchi_asiago.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "rice",
+      "nori"
+    ],
+    "recipeIngredient": [
+      "Riso bianco cotto al vapore (deve essere bello fumante)",
+      "Kimchi",
+      "Formaggio Asiago",
+      "Alga Nori",
+      "Olio di semi q.b."
+    ],
+    "instructionsText": "Iniziamo la preparazione tritando finemente al coltello il kimchi e grattugiando il formaggio Asiago. In una ciotola capiente, uniamo questi due ingredienti al riso. È fondamentale che il riso sia ancora ben caldo, mi raccomando bello fumante, affinché i sapori si amalgamino perfettamente e il formaggio inizi a sciogliersi. Mescoliamo il composto con gran delicatezza: non vogliamo fare un pappone. Passiamo ora alla formatura. Ci bagniamo ben bene le mani con l'acqua per impedire al riso di appiccicarsi e iniziamo a striangolare il composto, compattandolo fino a dargli la classica forma a triangolo. Non preoccupatevi se all'inizio non vengono dei bellissimi onigiri. Un trucco professionale per assicurarci che tengano bene la forma è avvolgere ogni onigiri con della pellicola da cucina e farli riposare per una mezz'oretta, affinché si compattino bene. Trascorso il tempo di riposo, ungiamo una padella con un po' di olio di semi e la scaldiamo a fuoco basso. Adagiamo delicatamente i nostri onigiri e li facciamo croccare a fiamma bassa da tutti i lati, ma proprio tutti. Per completare, come dei veri professionisti, facciamo croccare la nostra alga nori passandola rapidamente a fiamma viva sul fornello. Capirete che è bella secca quando si spezzerà da sola. Aggiungiamo l'alga all'ultimo momento, a mo' di tovagliolino edibile, in maniera che rimanga bella croccante mentre addentiamo il nostro onigiri filante e saporito."
+  },
+  "ricette/riso/oyakodon": {
+    "docId": "ricette/riso/oyakodon",
+    "title": "Oyakodon",
+    "description": "L'Oyakodon e' la carbonara giapponese",
+    "image": "/img/ricette/oyakodon.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "mirin",
+      "negi",
+      "rice",
+      "sake"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "L'Oyakodon va fatto su una padellina monoporzione, perche' poi lo fai scivolare tutto direttamente sulla ciotola di riso (caldo) Taglia la cipolla a fettine secondo la lunghezza della cipolla, il pollo a cubetti, e le cipolline a rondelle o losanghe. Rompi le uova in una ciotolina, e mescolale delicatamente (senza sbatterle) con le bacchette. Marina il pollo nel sake per 20 minuti. Asciuga bene il pollo e fallo rosolare a fuoco basso girandolo una sola volta quando si e' dorato. Quando e' dorato da entrambi i lati, toglierlo dalla padellina e metterlo da parte. Versa il dashi, il mirin e la salsa di soia nel pentolino, accendi il fuoco, aggiungi le cipolle e fai sobollire a fuoco medio-basso per 4 minuti. A questo punto abbassa la fiamma, e aggiungi il pollo. Fai sobollire per altri 2 minuti, fin quando il pollo non e' completamente cotto e il brodo non si e' ristretto un po'. Alza il fuoco a medio, versa delicatamente 2/3 dell'uovo cercando di coprire tutto. Mischia il resto dell'uovo alle cipolline e mettilo da parte. Fai andare 30-40 secondi a fuoco medio, poi abbassa la fiamma e cuoci un altro minuto, il brodo non si deve essere asciugato. Mischia molto delicatamente, e versa il restante uovo con le cipolline. A questo punto, spegni pure la fiamma e fai cuocere con il calore residuo per un altro minuto. La ricetta originale (come piace a me) prevede che l'uovo resti mezzo crudo e bello bavoso. Trasferisci il contenuto del pentolino direttamente sul riso facendocelo scivolare sopra. Servire caldo."
+  },
+  "ricette/riso/soborodon": {
+    "docId": "ricette/riso/soborodon",
+    "title": "Soboro Don",
+    "description": "La colorata e sfiziosa ciotola di riso giapponese a base di pollo e uova strapazzate, perfetta per un pasto ricco di proteine",
+    "image": "/img/ricette/soboro_don.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "beni_shoga",
+      "mirin",
+      "shoyu",
+      "rice",
+      "sake",
+      "pollo",
+      "uova"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Iniziamo occupandoci delle uova, che andranno a formare la prima metà del nostro colorato mosaico. Rompiamo le uova in una ciotola, sbattiamole leggermente con le bacchette e versiamole in una padella scaldata con un filo d'olio. Dobbiamo strapazzarle in modo continuo e veloce, cercando di creare dei grumi piccoli e soffici, senza seccarle troppo. Una volta pronte, trasferiamole su un piatto e teniamole da parte. Nella stessa padella (non serve lavarla), inseriamo la carne macinata di pollo cruda. Aggiungiamo subito i condimenti: il mirin, il sake, la salsa di soia e lo zenzero fresco grattugiato. Accendiamo il fuoco e iniziamo a cuocere sgranando la carne in continuazione con una spatola di legno. Questo passaggio è fondamentale: la carne deve cuocersi sminuzzandosi il più possibile, assorbendo tutti i liquidi della marinatura. Continuiamo la cottura fino a quando il sughetto sul fondo non si sarà quasi completamente asciugato, lasciando il macinato saporito e ben sgranato. Ora arriva il momento più divertente: l'assemblaggio. Prepariamo una ciotola capiente creando una base soffice di riso bianco. Disponiamo le uova strapazzate su una metà della ciotola e il macinato di pollo sull'altra metà. Per separare queste due \"tifoserie\", creiamo una coreografica linea di demarcazione centrale utilizzando i piselli sbollentati. Infine, per dare un tocco di acidità che pulisce il palato e un accento di colore rosso vivo, adagiamo al centro un ciuffetto di beni shoga. Il vostro Soboro Don è pronto per essere ammirato e, soprattutto, divorato!"
+  },
+  "ricette/riso/takenoko_to_aburaage_takikomi_gohan": {
+    "docId": "ricette/riso/takenoko_to_aburaage_takikomi_gohan",
+    "title": "Takenoko to Aburaage no Takikomi Gohan",
+    "description": "Un classico piatto casalingo giapponese, il Takikomi Gohan è un riso magico cotto comodamente nel cuociriso insieme ai suoi condimenti.",
+    "image": "/img/ricette/takenoko_to_aburaage_no_takikomi_gohan.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "rice",
+      "shoyu",
+      "mirin",
+      "sake",
+      "negi"
+    ],
+    "recipeIngredient": [
+      "1 misurino di Riso bianco varietà originario",
+      "Tofu fritto (Aburaage)",
+      "Germogli di bambù (Takenoko)",
+      "1 cucchiaio di Salsa di soia (Shoyu)",
+      "1 cucchiaio di Mirin",
+      "1 cucchiaio di Sake",
+      "1 cucchiaino di Dashi in polvere",
+      "Acqua q.b.",
+      "Cipollotto verde (Negi)"
+    ],
+    "instructionsText": "Per prima cosa ci occupiamo del tofu fritto, che necessita di un passaggio specifico: va lavato abbondantemente con acqua bollente, poi va strizzato con le mani e ben asciugato con della carta assorbente per fargli perdere tutto l'olio in eccesso. Una volta sgrassato, lo tagliamo a fettine sottili. Procediamo tagliando a fette anche il germoglio di bambù e immergiamo la parte verde del cipollotto tagliata a rondelle in una ciotola con acqua e ghiaccio. Passiamo alla preparazione del riso: utilizziamo un misurino preciso di varietà originario e lo laviamo più volte, scolandolo e massaggiandolo sotto l'acqua, finché l'acqua di risciacquo non diventerà completamente trasparente. Quando siamo soddisfatti del risultato, scoliamo bene il riso. Nello stesso misurino del riso uniamo la salsa di soia, il mirin, il sake e il dashi in polvere. A questa miscela di sapori aggiungiamo dell'acqua fresca fino a raggiungere lo stesso esatto volume del riso utilizzato in partenza. Se vogliamo fare più porzioni, basta moltiplicare tutto per il numero di misurini di riso che vogliamo cuocere. A questo punto componiamo il piatto direttamente nel cestello del cuociriso: inseriamo sul fondo il riso pulito, versiamo tutto il liquido e disponiamo sulla superficie i pezzetti di bambù e tofu fritto. Avviamo la cottura e lasciamo compiere la magia. Una volta terminata la cottura, apriamo il coperchio e diamo una bella mescolata al riso, portando in superficie la crosticina che si sarà formata sul fondo. Non ci resta che impiattare in una ciotola, guarnire con le magiche cipolline scolate dall'acqua e ghiaccio, e gustare."
+  },
+  "ricette/riso/takikomi_gohan": {
+    "docId": "ricette/riso/takikomi_gohan",
+    "title": "Takikomi Gohan",
+    "description": "Takikomi Gohan (Riso misto) 炊き込みご飯 - Riso svuotafrigo cotto direttamente nella risiera",
+    "image": null,
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "mirin",
+      "rice",
+      "shiitake"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Quando lavi il riso poi lascialo a bagno una mezz’ora e poi un quarto d’ora ad asciugare: assorbira’ meglio il condimento Metti gli shiitake a mollo nel dashi tiepido, dopo mezz’ora filtra il tutto, otterrai lo shiitake dashi. Nella risiera metti il riso, il sale (non te lo scordare, molto poco ma ci vuole) la soia e il mirin, lo shiitake dashi (deve essere della stessa quantita’ in volume del riso) e mischia bene, fai depositare il riso e poi sopra metti, a strati, gli ingredienti, dal più duro al piu’ morbido. Accendi la risiera e non toccare, gira solo quando ha finito, e vedrai che ti mangi."
+  },
+  "ricette/sides/bieta_gialla_ohitashi": {
+    "docId": "ricette/sides/bieta_gialla_ohitashi",
+    "title": "Bieta gialla ohitashi",
+    "description": "Un contorno di verdure vegano, senza grassi e ricco di storia",
+    "image": "/img/ricette/bieta-ohitashi.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [],
+    "recipeIngredient": [
+      "1 mazzo di bieta gialla (facilmente reperibile anche in Italia)",
+      "120 ml di Dashi (anche in versione vegana)",
+      "1 cucchiaio di Mirin",
+      "1 cucchiaio di Salsa di soia (Shoyu)",
+      "Sale q.b."
+    ],
+    "instructionsText": "Per prima cosa, portiamo a bollore abbondante acqua e la saliamo generosamente. La bieta ha consistenze diverse tra gambo e foglia, quindi richiede una cottura scaglionata. Immergiamo prima i gambi nell'acqua bollente tenendo le foglie fuori, calcolando circa 30-40 secondi. Trascorso questo tempo, spingiamo sotto anche tutta la parte fogliare e proseguiamo la cottura per altri 30 secondi. La verdura deve rimanere croccante e \"al dente\". Scoliamo la bieta e la tuffiamo immediatamente in una ciotola piena di acqua e ghiaccio. Questo passaggio fondamentale serve a fermare la cottura e a far raffreddare benissimo le foglie, fissando un colore verde brillante (e un giallo acceso per i gambi). Una volta fredda, allineiamo le foglie in modo ordinato e procediamo a strizzarle con molta cura. Partendo dai gambi e scendendo verso le punte, applichiamo un movimento \"strizzatorio\" deciso per eliminare tutta l'acqua in eccesso, che altrimenti annacquerebbe il condimento. Disponiamo la bieta compatta su un tagliere e la tagliamo in porzioni uguali, calcolando la misura in base al contenitore di vetro in cui la faremo riposare. Adagiamo i mazzetti tagliati nel contenitore con delicatezza e ordine. A parte, prepariamo la marinatura unendo il dashi, il mirin e la salsa di soia, assaggiando e correggendo le dosi a seconda del proprio gusto. Versiamo questo liquido sulle verdure in modo da coprirle. Per assicurarci che tutta la bieta resti uniformemente a contatto con il liquido, copriamo la superficie con un panno di carta da cucina, che si inzupperà fungendo da coperchio a contatto. Chiudiamo il contenitore e lasciamo riposare in frigorifero per qualche ora. Al momento di servire, con la pazienza di un giocatore di shangai, preleviamo i mazzetti e li disponiamo in maniera fotogenica in una ciotolina, ricordandoci di versare sopra qualche cucchiaio del loro squisito brodino freddo."
+  },
+  "ricette/sides/burokkori_no_okaka-ae": {
+    "docId": "ricette/sides/burokkori_no_okaka-ae",
+    "title": "Burokkori no okaka-ae",
+    "description": "Un contorno giapponese velocissimo, dal colore brillante e ricco di umami, perfetto per esaltare i broccoli.",
+    "image": "/img/ricette/burokkori_no_okaka-ae.png",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "verdure",
+      "sides",
+      "katsuobushi"
+    ],
+    "recipeIngredient": [
+      "1 testa di broccoli",
+      "1 cucchiaio di olio di sesamo (facoltativo ma consigliato)",
+      "1 cucchiaio di salsa di soia (shoyu)",
+      "Sesamo tostato q.b.",
+      "Katsuobushi (fiocchi di tonnetto essiccato) in abbondanza"
+    ],
+    "instructionsText": "Iniziamo dividendo i broccoli in cimette di dimensioni omogenee. Per la cottura tradizionale, sbollentiamo i broccoli in acqua per un paio di minuti: l'obiettivo è ammorbidirli leggermente mantenendoli però ben croccanti e tenaci al morso. Il passaggio fondamentale arriva subito dopo la scolatura: i broccoli caldi vanno letteralmente fiondati in una ciotola con acqua e ghiaccio. Questo shock termico serve a fermare immediatamente la cottura, fissare la loro naturale croccantezza e, soprattutto, a preservare quella meravigliosa \"verdosità\" e brillantezza che rende il piatto appagante anche alla vista. Una volta ben freddi, scoliamoli accuratamente e trasferiamoli in una ciotola capiente. Passiamo al condimento: aggiungiamo un cucchiaio di salsa di soia e un cucchiaio di olio di sesamo. Quest'ultimo non fa parte della ricetta canonica e tradizionale, ma regala una spinta aromatica che si sposa divinamente con gli altri sapori. Sgrattugiamo abbondante sesamo tostato direttamente sui broccoli e, infine, aggiungiamo il vero protagonista del piatto: una generosa manciata di katsuobushi. Diamo una bella mescolata per distribuire uniformemente i sapori e serviamo su un bel piatto di portata."
+  },
+  "ricette/sides/horenso_no_ohitashi": {
+    "docId": "ricette/sides/horenso_no_ohitashi",
+    "title": "Hōrensō no ohitashi",
+    "description": "Un contorno fondamentale della cucina giapponese: spinaci sbollentati e marinati in un brodo dashi delicato.",
+    "image": "/img/ricette/horenso_no_ohitashi.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "vegan",
+      "mirin",
+      "shoyu"
+    ],
+    "recipeIngredient": [
+      "2 mazzi di Spinaci",
+      "1 cucchiaino colmo di Sale (per la bollitura)"
+    ],
+    "instructionsText": ""
+  },
+  "ricette/sides/mugen_oba_nasu": {
+    "docId": "ricette/sides/mugen_oba_nasu",
+    "title": "Mugen Oba Nasu",
+    "description": "Un piatto velocissimo dove le melanzane tenere incontrano la freschezza dello shiso e una salsa agrodolce irresistibile.",
+    "image": null,
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "sesamo",
+      "shiso"
+    ],
+    "recipeIngredient": [
+      "2 Melanzane grandi (circa 300g)",
+      "5 foglie di Shiso",
+      "1 cucchiaio di Olio vegetale"
+    ],
+    "instructionsText": "In una ciotola capiente, unire tutti gli ingredienti per la salsa: salsa di soia, aceto, zucchero, brodo granulare, aglio, zenzero e semi di sesamo. Mescolare bene e mettere da parte. Rimuovere il gambo dalle foglie di shiso e tagliarle a julienne. Tagliare le melanzane: rimuovere il picciolo, dividerle a metà per il lungo e poi tagliare ogni metà in 3 o 4 spicchi a forma di ventaglio. Immergere gli spicchi in acqua per 5-10 minuti per eliminare l'amaro, quindi scolarli e asciugarli molto bene. Mettere le melanzane asciutte in una padella, aggiungere l'olio e mescolare per ungerle uniformemente. Cuocere a fuoco medio, prima dal lato della buccia e poi su tutti i lati, finché non saranno tenere e ben dorate. Trasferire le melanzane ancora calde direttamente nella ciotola con la salsa. Aggiungere la maggior parte dello shiso (tenendone un po' da parte per la guarnizione) e mescolare bene il tutto. Impiattare subito e guarnire con lo shiso rimasto."
+  },
+  "ricette/sides/nametake": {
+    "docId": "ricette/sides/nametake",
+    "title": "Nametake",
+    "description": "Una ricetta giapponese \"casalinga\" facilissima ed economica. Funghi Enoki cotti in salsa di soia e mirin, perfetti sul riso.",
+    "image": "/img/ricette/nametake.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "enoki",
+      "mirin",
+      "rice",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "1 confezione di Funghi Enoki",
+      "2 cucchiai di Salsa di Soia",
+      "2 cucchiai di Mirin",
+      "1 cucchiaio di Sake",
+      "1 cucchiaino di Zucchero",
+      "1 cucchiaio di Aceto di Riso"
+    ],
+    "instructionsText": "Per iniziare, prendi il mazzetto di funghi Enoki e rimuovi con un coltello la base del cespo (la parte con le radici), quindi taglia i funghi restanti in tre parti uguali. Trasferisci tutto in un pentolino e aggiungi direttamente a freddo i condimenti: la salsa di soia, il mirin, il sake e il cucchiaino di zucchero. Accendi il fornello e fai cuocere a fuoco medio per circa 5 minuti, mescolando di tanto in tanto; noterai che i funghi rilasceranno la loro acqua e si ammorbidiranno rapidamente. Quando la salsa di cottura si sarà leggermente ritirata e addensata, versa un cucchiaio di aceto di riso e lascia andare sul fuoco ancora per un paio di minuti per far amalgamare bene i sapori. A questo punto il Nametake è pronto: puoi servirlo immediatamente sopra una ciotola di riso fumante o trasferirlo in un barattolo per conservarlo in frigorifero."
+  },
+  "ricette/sides/nasu_dengaku": {
+    "docId": "ricette/sides/nasu_dengaku",
+    "title": "Nasu Dengaku",
+    "description": "Melanzane al miso",
+    "image": "/img/ricette/nasudengaku.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "sides",
+      "vegetarian",
+      "vegan"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Metti subito a scaldare il grill del forno Tagliare la melanzana in 2, e inciderla a losanga (profondità’ 4-5 mm) per farla cuocere più’ uniformemente Mettere le melanzane in una padella con poco olio (arachide o girasole) caldo, dal lato della pelle, e farle cuocere senza coperchio per 2-3 minuti, girarle e farle cuocere dall’altro lato per altri 2-3 minuti. Se sono molto spesse mettere il coperchio. Mettere le melanzane in una teglia e spennellarle con la glassatura di miso, finire la cottura in forno con il grill al massimo, per 5 minuti o finche non sono dorate Vacci piano col miso che senno’ ti vengono salate Guarnire con negi (o cipolline)"
+  },
+  "ricette/sides/nasu_no_yaki-bitashi": {
+    "docId": "ricette/sides/nasu_no_yaki-bitashi",
+    "title": "Nasu no Yaki-bitashi",
+    "description": "Nasu no Yaki-bitashi, ovvero melanzane grigliate in brodo - Un'alternativa più leggera e salutare alle classiche melanzane fritte (Agebitashi), che richiede solo due cucchiai d'olio per un risultato tenero, succoso e pieno di sapore.",
+    "image": null,
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "daikon",
+      "katsuobushi",
+      "mirin",
+      "shiso"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Preparare il brodo di marinatura mescolando in una caraffa l'acqua, la salsa di soia, il mirin, lo zucchero, il dashi in polvere e lo zenzero grattugiato. Lavare e asciugare molto bene le melanzane. Rimuovere il picciolo e tagliarle a metà per il lungo. Con un coltello, incidere la superficie della buccia con tagli diagonali poco profondi, per favorire la cottura e l'assorbimento del sapore. Disporre le melanzane in una padella capiente. Spennellarle uniformemente su tutta la superficie (prima la buccia, poi la polpa) con i due cucchiai di olio. Cuocere a fuoco medio con la buccia rivolta verso il basso per circa 2-3 minuti. Girare le melanzane, abbassare la fiamma al minimo, coprire con un coperchio e cuocere lentamente finché la polpa non sarà tenera e ben dorata. Versare il brodo preparato direttamente nella padella sopra le melanzane. Alzare la fiamma a fuoco medio e portare a ebollizione. Appena il liquido bolle, spegnere immediatamente il fuoco. Trasferire con delicatezza le melanzane e tutto il loro brodo in un contenitore per alimenti. Lasciare raffreddare completamente a temperatura ambiente, dopodiché coprire e riporre in frigorifero a insaporire per almeno 3 ore. Servire le melanzane fredde, irrorandole con il loro brodo di marinatura e guarnendo a piacere con foglie di shiso tritate o katsuobushi."
+  },
+  "ricette/sides/potetosarada": {
+    "docId": "ricette/sides/potetosarada",
+    "title": "Potetosarada",
+    "description": "Insalata di patate",
+    "image": "/img/ricette/potetosarada.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "sides",
+      "vegetarian",
+      "kewpie",
+      "mirin",
+      "rice"
+    ],
+    "recipeIngredient": [
+      "Patate a pasta gialla 1 kg",
+      "Maionese Kewpie 250 ml circa (regolabili a piacere)",
+      "Cetriolo 1 grande",
+      "1 Cipolla media",
+      "2 Carote medie",
+      "1 cucchiaio di mirin",
+      "Aceto di riso 1 cucchiaio",
+      "Zucchero 2 cucchiaini circa",
+      "Sale qb",
+      "Pepe qb"
+    ],
+    "instructionsText": "Mettere a bollire le patate. Tagliare il cetriolo e la cipolla sottilissimi, metterli in uno scolapasta con un po' di sale e metterci sopra un canovaccio con un peso. Far drenare per 15-20 minuti. Dopo, eliminare il sale in eccesso (anche con una sciaquata veloce) e strizzare bene con un canovaccio (mi raccomando bene) Sbollentare le carota sbucciate per qualche minuto, poi tagliarle a fettine o cubetti (come prederite) Una volta che le patate sono pronte, sbucciarle senza scottarsi, metterle in una terrina e schiacciarle con una forchetta come per fare il pure', lasciando dei pezzetti per avere una consistenza piu' varia (aho poi a me piacciono cosi poi voi fate come vi pare) Aggiungere cetriolo, cipolla, carota, la maionese, il mirin e l'aceto di riso, lo zucchero, il sale e il pepe e mescolare. I condimenti finali vanno un po' a piacere, soprattutto per quanto riguarda lo zucchero."
+  },
+  "ricette/sides/unagi-di-melanzane": {
+    "docId": "ricette/sides/unagi-di-melanzane",
+    "title": "Unagi di melanzane",
+    "description": "La Melanzana che voleva essere un'Anguilla! Una ricetta vegana così buona che la sceglierebbe anche un onnivoro.",
+    "image": "/img/ricette/unagi_di_melanzane.jpg",
+    "recipeCategory": "Contorni",
+    "recipeKeywords": [
+      "vegan",
+      "Semi di sesamo",
+      "Cipolline verdi",
+      "mirin",
+      "potato_starch",
+      "rice",
+      "sake",
+      "sesamo"
+    ],
+    "recipeIngredient": [
+      "1 Melanzana",
+      "Fecola di patate",
+      "1 cucchiaio di Sakè da cucina",
+      "1 cucchiaio di Mirin",
+      "2 cucchiai di Salsa di Soia",
+      "1 cucchiaino di Zucchero",
+      "Olio di semi di sesamo per la cottura",
+      "Riso bianco cotto per servire",
+      "Semi di sesamo tostati per guarnire",
+      "Cipolline verdi per guarnire"
+    ],
+    "instructionsText": "Sbucciare una striscia sì e una striscia no (come la divisa della Juve). Poi incartarla in un foglio di carta da cucina bagnato e strizzato, e poi nella pellicola per alimenti. Così avvolta, metterla in un microonde per 2-3 minuti alla massima potenza per accelerare la cottura. Scartarla e, con una forchetta, incidere dei solchi sulla polpa nel senso della lunghezza per imitare la consistenza di un'anguilla. Dopodiché, spennellarla con della fecola di patate, spennellando via l'eccesso. La salsa di cottura: In una ciotolina prepariamo la salsa mescolando sakè, mirin, salsa di soia e lo zucchero. In padella!: Metterla in una padella con un filo d'olio di semi e ripassarla a fuoco medio da ambo i lati, per farla diventare fuori croccantissima e dentro morbidissima. La glassatura: A questo punto, le concediamo un bel bagnetto versando la salsa di cottura direttamente in padella. A fuoco lentissimo, lasciamo che la salsa si riduca e glassi la melanzana. Ecco la trasformazione. Il gran finale: \"Sono un'anguilla, sono un'anguilla!\" gridava la nostra melanzana. E le fu preparato un letto di riso trionfale su cui fu dolcemente adagiata. Per guarnirla, come farle mancare dei semi di sesamo appena tostati e delle gloriose cipolline verdi? E la nostra melanzana è diventata un'anguilla."
+  },
+  "ricette/tsukemono/daikon": {
+    "docId": "ricette/tsukemono/daikon",
+    "title": "Daikon-dzuke (大根の漬物)",
+    "description": "Daikon piccante sott'aceto",
+    "image": null,
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [
+      "daikon",
+      "rice",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "450g daikon",
+      "1 peperoncino rosso secco",
+      "2 cucchiai aceto di riso",
+      "1 cucchiaino di sake (opzionale)",
+      "1 cucchiaio di sale marino in fiocchi o mezzo cuucchiaio di sale in polvere",
+      "⅓ cup sugar (provato con 2 cucchiai grandi)"
+    ],
+    "instructionsText": "Taglia il daikon a meta', e poi a fettine di 5mm circa di spessore, ottenendo delle mezze lune. Mischia tutto molto bene e metti in un sacchetto di plastica a chiusura ermetica, cercando di far uscire tutta l'aria. All'inizio il liquido di marinatura sembrera' un po' poco, ma con il tempo il daikon, grazie al sale, espellera' un sacco di acqua. Metti in frigorifero, e' buono dopo 2-3 ore, ma suggerisco di aspettare almeno una settimana. Non ho idea di quanto si conservi, ma ne ho trovato uno dimenticato in frigo da mesi, ed era il migliore che avessi provato (e sono ancora vivo mesi dopo). Suppongo che se vada a male, sia anche facile accorgersene."
+  },
+  "ricette/tsukemono/daikon_shiokombuzuke": {
+    "docId": "ricette/tsukemono/daikon_shiokombuzuke",
+    "title": "Daikon Shiokombuzuke",
+    "description": "Daikon marinato con shio kombu, sesamo e shoyu. Una bomba di umami!",
+    "image": "/img/ricette/daikon_shiokombuzuke.jpg",
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [
+      "daikon",
+      "kombu",
+      "sesame_oil",
+      "sesamo",
+      "shoyu"
+    ],
+    "recipeIngredient": [
+      "500g di Daikon",
+      "Sale (circa 2 cucchiai abbondanti per la spurgatura)",
+      "Shio Kombu (striscioline di alga kombu salata)",
+      "Peperoncino (a filetti o a scaglie)",
+      "2 cucchiai di Olio di sesamo",
+      "2 cucchiai di Shoyu (salsa di soia)",
+      "1 cucchiaio di Zucchero"
+    ],
+    "instructionsText": "Per prima cosa, prepara il daikon: taglialo in pezzi lunghi circa 6-7 cm, poi affettalo e ricavane delle listarelle. Metti le listarelle in una ciotola capiente e aggiungi il sale (\"copioso\", circa due cucchiai per mezzo chilo di daikon). Mischia bene con le mani per distribuirlo ovunque. Trasferisci il tutto in un colino, posiziona un piattino con un peso sopra (un barattolo pieno d'acqua va benissimo) e lascia riposare per circa mezz'ora. Il daikon rilascerà moltissima acqua. Passata la mezz'ora, sciacqua velocemente il daikon sotto l'acqua corrente per rimuovere il sale in eccesso. Ora la parte fondamentale: strizzalo con forza! Prendi un barattolo di vetro e inizia a comporre gli strati alternando: 1. Una dose di Daikon strizzato; 2. Una presa di Shio Kombu (l'ingrediente segreto, una vera bomba umami); 3. Un po' di peperoncino. Ripeti fino a riempire il barattolo. Per il condimento finale, versa nel barattolo: l'olio di sesamo, la salsa di soia e lo zucchero. Chiudi il barattolo e agita energicamente per amalgamare tutto. Metti in frigorifero. Sebbene basti qualche ora, lasciarlo riposare una notte intera è il top per far insaporire bene il tutto. Si conserva per qualche giorno, ma è così buono che finirà subito! Itadakimasu!"
+  },
+  "ricette/tsukemono/gari": {
+    "docId": "ricette/tsukemono/gari",
+    "title": "Gari",
+    "description": "Zenzero marinato",
+    "image": null,
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [],
+    "recipeIngredient": [
+      "250g zenzero fresco",
+      "1 cucchiaino di sale fino"
+    ],
+    "instructionsText": "Sbuccia lo zenzero raschiandolo con un cucchiaio, e lavalo con acqua fredda. Taglialo a fettine sottili, usando un pelapatate o una mandolina, e mettile in una ciotola. Aggiungi un cucchiaio di sale e lascia riposare per 10 minuti, viene meglio ancora se lo metti sotto un peso per far rilasciare il liquido. Intanto metti una pentola con l'acqua sul fuoco, e porta a bollore. Strizza bene lo zenzero, e mettilo a bollire per 1-2 minuti. Se lo zenzero e' molto piccante, puoi bollirlo per 2-3 minuti. Scolalo bene e distribuiscilo su un panno pulito, e lascialo asciugare finche' non si fredda completamente. Strizzalo bene e mettilo in un barattolo di vetro sterilizzato. Mentre lo zenzero asciuga, prepara l'amazu. Metti l'aceto, lo zucchero e il sale in una pentola, e porta a bollore. Lascia bollire per 1-2 minuti, finche' lo zucchero non si e' sciolto completamente. Lascia raffreddare completamente. Versa l'amazu sullo zenzero, e lascia riposare per 1-2 giorni prima di consumarlo. Si conserva per mesi in frigo."
+  },
+  "ricette/tsukemono/kyuri-no-tsukemono": {
+    "docId": "ricette/tsukemono/kyuri-no-tsukemono",
+    "title": "Kyuri no Tsukemono",
+    "description": "Cetrioli sottaceto veloci",
+    "image": null,
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [
+      "senape_karashi"
+    ],
+    "recipeIngredient": [
+      "1 Cetriolo",
+      "Sale q.b.",
+      "2 cucchiaini di Sushisu (aceto per sushi)",
+      "1 cucchiaino di senape Karashi (in alternativa, va bene anche la senape comune)"
+    ],
+    "instructionsText": "Per prima cosa, preparare il cetriolo. Con la lama di un coltello, raschiare via le asperità dalla buccia. Spargere un po' di sale su un tagliere e massaggiare vigorosamente il cetriolo sul sale per qualche istante. Eliminare il sale in eccesso e inserire il cetriolo (tagliato a metà se necessario) in un sacchetto di plastica per alimenti. Aggiungere nel sacchetto i due cucchiaini di sushisu e il cucchiaino di senape. Per creare un effetto \"sottovuoto dei poveri\", immergere il sacchetto in acqua (lasciando l'apertura fuori) per far uscire tutta l'aria, quindi sigillarlo. Mettere il sacchetto in frigorifero a marinare per qualche ora. Una volta pronto, togliere il cetriolo dal sacchetto, tagliarlo in quarti per il lungo, eliminare i semi interni e poi tagliarlo a tocchetti. Disporre i pezzi su un piattino, condire con un po' del liquido di marinatura avanzato nel sacchetto e servire. Itadakimasu!"
+  },
+  "ricette/tsukemono/ninniku-no-misozuke": {
+    "docId": "ricette/tsukemono/ninniku-no-misozuke",
+    "title": "Ninniku no Misozuke",
+    "description": "Aglio conservato sotto miso",
+    "image": null,
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [
+      "mirin",
+      "miso",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "150g miso chiaro",
+      "25ml di sake",
+      "45ml di mirin",
+      "3 teste d'aglio"
+    ],
+    "instructionsText": "Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro. Tagliare gli spicchi per il lungo e togliere l'anima. Mettere gli spicchi d'aglio su una griglia, e lasciare asciugare tutta la notte. Questo aiuta a concentrare il sapore dell'aglio e a ridurre la quantita' di umidita' al suo interno. Mescolare il miso, il sake e il mirin in un piccolo pentolino, e scaldare mischiando per 2-3 minuti, fiche' non avra' assunto una consistenza liscia, cremosa e uniforme. Mettere il composto alternandolo a strati con l'aglio in un un barattolo. Far fermentare almeno 3 mesi in frigorifero."
+  },
+  "ricette/tsukemono/ninniku-shoyuzuke": {
+    "docId": "ricette/tsukemono/ninniku-shoyuzuke",
+    "title": "Ninniku Shoyuzuke (ニンニク醤油漬け)",
+    "description": "Aglio conservato in salsa di soia",
+    "image": null,
+    "recipeCategory": "Marinati",
+    "recipeKeywords": [
+      "rice"
+    ],
+    "recipeIngredient": [
+      "1 tazza di spicchi di aglio",
+      "3/4 tazza di zucchero (a me sembra troppa)",
+      "1 tazza di salsa di soia",
+      "1/2 tazza di aceto di riso"
+    ],
+    "instructionsText": "Mettere la salsa di soia, lo zucchero e l'aceto di riso in un pentolino, portare a bollore e spegnere il fuoco. Versare il preparato in un barattolo di vetro sterilizzato insieme all'aglio. Chiudere il barattolo e mettere in frigo. Il composto e' pronto dopo 3-4 settimane (meglio 4-5) e si conserva in frigo almeno 12 settimane."
+  },
+  "ricette/yakimono/gyoza": {
+    "docId": "ricette/yakimono/gyoza",
+    "title": "Gyoza",
+    "description": "Ravioli alla piastra",
+    "image": "/img/ricette/gyoza1.jpg",
+    "recipeCategory": "Griglia",
+    "recipeKeywords": [
+      "negi",
+      "sake",
+      "sesame_oil",
+      "sesamo",
+      "shiitake"
+    ],
+    "recipeIngredient": [
+      "250g di carne di maiale macinata, preferite un taglio grasso come il collo.",
+      "500g di cavolo cinese",
+      "2 spicchi d'aglio",
+      "1 cucchiaio di zenzero fresco grattugiato",
+      "1 pizzico di sale",
+      "pepe nero macinato a piacere",
+      "2 cipolline verdi/negi",
+      "2 funghi shiitake (opzionali)",
+      "2 cucchiai di olio di sesamo",
+      "2 cucchiai di salsa di soia",
+      "2 cucchiai di sake"
+    ],
+    "instructionsText": "Tritare finemente il cavolo e metterlo in una ciotola con un cucchiaio di sale. Lasciar riposare per 10 minuti, poi sciacquate e strizzare bene il cavolo per eliminare l'acqua in eccesso. Mentre il cavolo sta li per conto suo a perdere acqua, tritare finemente l'aglio, lo zenzero e le cipolline verdi. Mettere tutto in una ciotola con la carne di maiale e gli altri ingredienti e mescolare finché non si rompono le proteine della carne e il composto diventa omogeneo e quasi colloso. Con un cucchiaino, prendere un po' di ripieno e metterlo al centro di una sfoglia di pasta per gyoza. Bagnare i bordi con un po' d'acqua e chiudere a mezzaluna, facendo delle pieghe a ventaglio. Siccome faccio pena a chiudere i gyoza, vi linko un video di come si chiudono i gyoza: link Mettete i gyoza chiusi su un foglio di carta da forno, cosparso leggermente con della fecola di patate, o amido di mais. Questo non solo evita che i gyoza si attacchino al foglio, ma l'amido, sciogliendosi nell'acqua in cottura, fara' una splendida crosticina dorata. Piu' o meno il risultato e' questo (notare quello in basso a sinistra, detto anche Gyozimodo): !Gyoza"
+  },
+  "ricette/yakimono/isobeyaki": {
+    "docId": "ricette/yakimono/isobeyaki",
+    "title": "Isobeyaki",
+    "description": "Mochi grigliato avvolto nell'alga nori, uno snack semplice e \"pericolosamente\" buono",
+    "image": "/img/ricette/isobeyaki.jpg",
+    "recipeCategory": "Griglia",
+    "recipeKeywords": [
+      "snack",
+      "vegan",
+      "nori"
+    ],
+    "recipeIngredient": [
+      "Kirimochi (panetti di riso glutinoso essiccati)",
+      "Salsa di soia (Shoyu)",
+      "Alga Nori (tagliata a strisce)"
+    ],
+    "instructionsText": "Per questa ricetta partiamo dai Kirimochi, i classici blocchetti di mochi duri e rettangolari che si trovano in commercio. Il primo passaggio è la cottura: possiamo usare una griglia a maglia fine (se avete i fornelli a gas) oppure una semplice padella antiaderente. Cuociamo il mochi a fuoco medio. Vedrete che piano piano inizierà a gonfiarsi, dorarsi in superficie e diventare morbido. Una volta grigliato, il Kirimochi cambia nome e diventa Yakimochi (letteralmente \"mochi grigliato\"). Preparate una ciotolina con della salsa di soia. Prendete il mochi caldissimo direttamente dalla griglia e tuffatelo rapidamente nella soia, rigirandolo per farlo insaporire bene su entrambi i lati. Infine, prendete una striscia di alga nori e avvolgetela intorno al mochi ancora caldo: l'alga si attaccherà grazie all'umidità della soia e al calore, permettendovi di afferrarlo con le mani (facendo attenzione a non scottarvi). Ecco a voi l'Isobeyaki, pronto per essere addentato."
+  },
+  "ricette/yakimono/shogayaki": {
+    "docId": "ricette/yakimono/shogayaki",
+    "title": "Shogayaki",
+    "description": "Scaloppine di maiale allo zenzero",
+    "image": "/img/ricette/shogayaki.jpg",
+    "recipeCategory": "Griglia",
+    "recipeKeywords": [
+      "mirin",
+      "potato_starch",
+      "sake"
+    ],
+    "recipeIngredient": [
+      "4 fettine di arista di maiale, sottili ma non troppo, meno di 1 cm",
+      "fecola di patate per infarinare leggermente le fettine"
+    ],
+    "instructionsText": "Trita finemente lo zenzero, la mela e la cipolla, poi mescolali insieme agli altri ingredienti della salsa in una ciotola. Fai qualche taglietto sui bordi e sui nervetti delle fettine, come per i saltimbocca, per evitare che si accartoccino in cottura. Infarina leggerissimamente le fettine di maiale con la fecola di patate. Così leggermente che puoi usare un pennello, come fosse cipria. Anzi, meglio dire “incipriare” le fettine piuttosto che infarinarle. Scalda una padella antiaderente con un filo di olio. Metti a rosolare tutte le fettine da un lato per circa un minuto, o poco meno, finché sono ben rosolate. Girale e cuocile dall’altro lato per circa 30 secondi. A questo punto aggiungi la salsa direttamente in padella e lascia cuocere ancora per al massimo un minuto, giusto il tempo che la carne si insaporisca bene. Togli le fettine dalla padella e fai finire di addensare la salsa. Servi gli shogayaki guarnendo con la salsa rimasta."
+  },
+  "ricette/yakimono/teriyaki_chicken": {
+    "docId": "ricette/yakimono/teriyaki_chicken",
+    "title": "Pollo Teriyaki",
+    "description": "Il segreto per un pollo succoso e perfettamente caramellato",
+    "image": null,
+    "recipeCategory": "Griglia",
+    "recipeKeywords": [],
+    "recipeIngredient": [],
+    "instructionsText": "La chiave per un ottimo pollo teriyaki risiede nella gestione del calore e del grasso. Iniziamo disponendo la sovracoscia in un pentolino o una padella antiaderente ancora fredda, posizionandola con il lato della pelle verso il basso. Accendiamo il fuoco e lo regoliamo al minimo: il segreto è la lentezza. Lasciamo che il pollo rosoli dolcemente per circa 7-8 minuti; questo permetterà al grasso sottocutaneo di sciogliersi lentamente, rendendo la pelle croccante e sottile. Una volta che la pelle è ben dorata, giriamo il pollo e procediamo con la cottura dell'altro lato. Durante questa fase, è fondamentale utilizzare della carta assorbente per tamponare ed eliminare tutto il grasso in eccesso rilasciato dal pollo nella padella. Questo passaggio è cruciale per evitare che la salsa finale risulti untuosa. Continuiamo la cottura per altri 3-4 minuti fino a quando entrambi i lati saranno ben rosolati, quindi togliamo temporaneamente il pollo dalla padella e lasciamolo riposare. Prepariamo ora la salsa teriyaki nella stessa padella. Versiamo il mirin e il sake, alziamo leggermente la fiamma per far evaporare l'alcol e poi aggiungiamo la salsa di soia. Quando l'intruglio inizia a sobbollire, lasciamolo restringere per circa un minuto. Reintroduciamo il pollo nella padella e iniziamo a glassarlo con cura, girandolo più volte per farlo caramellare uniformemente su tutti i lati. Vogliamo che la salsa diventi splendente e affascinante, avvolgendo il pollo come una lacca. Infine, affettiamo il pollo a striscioline, come farebbe un vero chef di Hokuto, e disponiamolo coreograficamente su un letto di riso bianco al vapore. Non dimentichiamo di versare sopra tutta la salsa rimasta nella padella: sarebbe un delitto sprecarla."
+  },
+  "ricette/zuppe/misoshiru": {
+    "docId": "ricette/zuppe/misoshiru",
+    "title": "Misoshiru",
+    "description": "Zuppa di miso",
+    "image": "/img/ricette/misoshiru.jpg",
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "miso",
+      "negi",
+      "wakame"
+    ],
+    "recipeIngredient": [],
+    "instructionsText": "Portate il dashi a sfiorare il bollore. Se state preparando una zuppa di miso con verdure, funghi o altri ingredienti, aggiungeteli adesso e portateli a cottura prima del miso. Quando tutto è cotto, spegnete il fuoco e sciogliete il miso nel dashi aiutandovi con un setaccio o con un mestolino. Si può fare anche senza setaccio, ma in questo modo la zuppa resta più liscia e uniforme. Aggiungete il wakame, il tofu e il negi o il porro, poi servite subito."
+  },
+  "ricette/zuppe/osuimono": {
+    "docId": "ricette/zuppe/osuimono",
+    "title": "Osuimono Vegano",
+    "description": "Zuppa trasparente e delicatissima, una versione vegana facile facile.",
+    "image": null,
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "vegan",
+      "daikon",
+      "sesame_oil",
+      "sesamo"
+    ],
+    "recipeIngredient": [
+      "Un pezzo di Daikon",
+      "1 Carota piccola",
+      "1 Cipollina",
+      "4 tazze di Dashi vegano",
+      "Sale q.b."
+    ],
+    "instructionsText": "Tagliare il daikon a spicchietti e la carotina a mezze lune. Affettare la cipollina, separando la parte bianca (che andrà in cottura) da quella verde (che terremo da parte per guarnire). Mettere a scaldare il dashi vegano in una pentola. Mi raccomando, aggiungere subito il sale, non ve lo dimenticate! Appena il dashi bolle, buttare dentro tutte le verdurine tagliate: daikon, carota e la parte bianca della cipollina. Chiudere con il coperchio e cuocere per circa 10 minuti. La zuppa sarà pronta quando il daikon diventerà traslucido e stupendo. Servire la zuppa ben calda in una ciotola, guarnire con la parte verde della cipollina e completare con un filo d'olio di sesamo."
+  },
+  "ricette/zuppe/tofu_and_eggs": {
+    "docId": "ricette/zuppe/tofu_and_eggs",
+    "title": "Tofu in \"stracciatella\" con verdure",
+    "description": "Una ricetta buona, economica, sana, proteica e facile da fare.",
+    "image": "/img/ricette/tofu_and_eggs.jpg",
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "mirin",
+      "potato_starch",
+      "shiitake"
+    ],
+    "recipeIngredient": [
+      "Mezzo panetto di Tofu",
+      "1 Uovo",
+      "2-3 Funghi Shiitake freschi o reidratati",
+      "Mezza Carota",
+      "2 Cipolline",
+      "1 tazza di Dashi (o brodo vegetale)",
+      "1 cucchiaio di Salsa di soia",
+      "1 cucchiaio di Mirin",
+      "1 cucchiaino di Zucchero",
+      "1 cucchiaino di Fecola di patate"
+    ],
+    "instructionsText": "Preparare il brodo di cottura mescolando in una ciotola il dashi, la salsa di soia, il mirin e lo zucchero. Tagliare le verdure: affettare le carote a julienne, tagliare le cipolline a tocchetti grossolani e affettare i funghi shiitake dopo aver rimosso il gambo. Tagliare il tofu a cubetti non troppo piccoli. Versare il brodo preparato in un pentolino e aggiungere subito i cubetti di tofu, facendo attenzione a non romperli. Coprire e scaldare a fuoco medio per circa 10 minuti, finché non inizia a bollire. Togliere delicatamente il tofu cotto dal pentolino e metterlo da parte in un piatto fondo. Versare tutte le verdure tagliate (carote, funghi e cipolline) nello stesso brodo di cottura, coprire e cuocere per circa 5 minuti. Nel frattempo, sbattere leggermente un uovo in una ciotolina. In un'altra piccola ciotola, sciogliere la fecola di patate con un paio di cucchiai d'acqua fredda. Trascorsi i 5 minuti, versare la fecola sciolta nel pentolino con le verdure e mescolare per addensare leggermente il brodo. Creare un vortice nel brodo e versare a filo l'uovo sbattuto per creare l'effetto \"stracciatella\". Versare le verdure e il brodo sopra il tofu messo da parte nel piatto. La ricetta è pronta, e daje!"
+  },
+  "ricette/zuppe/vegan-misoshiru": {
+    "docId": "ricette/zuppe/vegan-misoshiru",
+    "title": "Zuppa di Miso Vegana",
+    "description": "La versione vegana della zuppa di miso.",
+    "image": "/img/ricette/vegan_misoshiru.jpg",
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "vegan",
+      "miso",
+      "wakame"
+    ],
+    "recipeIngredient": [
+      "Dashi vegano (brodo di alga kombu e funghi shiitake)",
+      "1 cucchiaio abbondante di Miso (nel video si usa il miso rosso o akamiso)",
+      "Alghe Wakame essiccate",
+      "Tofu (meglio se tofu morbido o silken tofu)",
+      "Cipolline verdi"
+    ],
+    "instructionsText": "Mettere in ammollo una manciata di alghe wakame in acqua fredda per farle rinvenire. Tagliare il tofu a cubetti. Portare a bollore il dashi vegano in una pentola. Appena bolle, aggiungere il tofu a cubetti e le alghe wakame reidratate. Cuocere per un paio di minuti. In una ciotolina a parte (o in un mestolo), stemperare il miso con un po' di brodo caldo per scioglierlo bene. È importante farlo a fuoco spento per non rovinare i fermenti. Spegnere il fuoco sotto la pentola e versare il miso sciolto nella zuppa. Mescolare bene. Servire subito in una ciotola e guarnire con delle cipolline fresche tagliate sottili."
+  },
+  "ricette/zuppe/zuppa_di_miso_e_funghi": {
+    "docId": "ricette/zuppe/zuppa_di_miso_e_funghi",
+    "title": "Zuppa di Miso e Funghi Vegana",
+    "description": "Una zuppa di miso vegana, perfetta per l'autunno, con shiitake, enoki e miso rosso.",
+    "image": "/img/ricette/zuppa-miso-funghi.jpg",
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "vegan",
+      "enoki",
+      "kombu",
+      "miso",
+      "shiitake"
+    ],
+    "recipeIngredient": [
+      "1 litro di Acqua fredda",
+      "1-2 pezzi di Alga Kombu",
+      "4-5 Funghi Shiitake secchi",
+      "1 mazzetto di Funghi Enoki",
+      "1-2 cucchiai di Miso Rosso (Aka Miso)",
+      "Cipollotto (Negi) per guarnire"
+    ],
+    "instructionsText": "Questa ricetta si prepara in due fasi: la preparazione del dashi (giorno 1) e la cottura della zuppa (giorno 2)."
+  }
+};

--- a/src/data/recipe-data.ts
+++ b/src/data/recipe-data.ts
@@ -8,6 +8,7 @@ export interface RecipeData {
   image: string | null;
   recipeCategory: string | null;
   recipeKeywords: string[];
+  recipeYield: string | null;
   recipeIngredient: string[];
   instructionsText: string;
 }
@@ -25,6 +26,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesamo",
       "potato_starch"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 confezione di funghi enoki",
       "2 cucchiai di salsa di soia o salsa yakiniku",
@@ -49,6 +51,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "kewpie",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Coscia e sottocoscia di pollo disossata, con la pelle",
       "1 cucchiaio di salsa di soia",
@@ -73,7 +76,15 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sake",
       "shiitake"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "4 persone",
+    "recipeIngredient": [
+      "120 ml di uovo, io uso 3 rossi e bianchi q.b. per arrivare a 120 ml",
+      "360 ml di dashi (rapporto di 3:1 con le uova)",
+      "30 ml di salsa di soia (meglio se chiara)",
+      "20 ml di mirin",
+      "20 ml di sake (opzionale)",
+      "un pizzico di sale"
+    ],
     "instructionsText": "Unire in una ciotola le uova, con il dashi, il mirin, la salsa di soia (se si vuole, il sake) e il sale. Mescolare bene con luna frusta, cercando di non incorporare aria. Setacciare il composto con un colino a maglie strette in un'altra ciotola, e versare il composto nelle ciotoline di ceramica. Mettere nelle ciotoline uno o due gamberi, un paio di ginnan, e un fungo shiitake fatto a fettine. Versare il composto nelle ciotoline, e coprire con un foglio di alluminio. Mettere le ciotoline nella pentola per il vapore, e cuocere a circa 90 gradi per 10 minuti. La cosa piu' semplice per mantenere la temperatura é mettere una bacchetta tra il coperchio e la pentola, per tenere il coperchio socchiuso. Tenere la fiamma appena sufficiente a far sobbollire l'acqua. A questo punto si possono aggiungere altre decorazioni, come l'edamame, o un gambero o delle capesante fatte a fettine, e cuocere per altri 2 minuti. Altrimenti, si puo' cuocere per 12-13 minuti senza aggiungere nulla. Spegnere il fuoco, e lasciare riposare per 7-8 minuti. A questo punto aggiungere un po' di prezzemolo o cipolline, e servire caldo. Alternativamente, si puo' mettere in frigorifero e gustare freddo, con del buon vino bianco o del sake."
   },
   "ricette/antipasti/hiyashi_nasu": {
@@ -85,6 +96,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "katsuobushi"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 o 2 Melanzane piccole e sode",
       "Cipolline verdi",
@@ -103,6 +115,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "katsuobushi",
       "negi"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 panetto di tofu morbido (meglio se silken tofu)",
       "2-3 cucchiai di salsa ponzu",
@@ -122,6 +135,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "kewpie",
       "teriyaki"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Fogli di carta di riso rotondi",
       "Alette di pollo (o avanzi di pollo arrosto/sfilacciato)",
@@ -143,6 +157,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesamo",
       "wakame"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 Cetriolo (se lo trovate, è molto meglio quello giapponese: stretto, lungo e sbruzzoloso)",
       "Alghe Wakame essiccate",
@@ -166,6 +181,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesame_oil",
       "sesamo"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Un quarto abbondante di Cavolo cappuccio",
       "1 cucchiaio di Olio di sesamo",
@@ -185,6 +201,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "negi",
       "shoyu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Moscardini (Iidako)",
       "Negi (cipollotti lunghi o porri giapponesi)",
@@ -202,6 +219,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Salmone",
       "Sale",
@@ -223,6 +241,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "udon",
       "daikon"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Udon confezionati (quelli freschi vanno benissimo, ma anche quelli secchi andranno bene)",
       "Un pezzo di 5cm di Daikon",
@@ -247,6 +266,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sake",
       "shiso"
     ],
+    "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Sbollentare la sovraccoscia di pollo in acqua bollente per un minuto, quindi scolarla e gettare l'acqua. Questo passaggio serve a pulire il pollo e a garantire un brodo più limpido. In una pentola, unire l'alga kombu, il pollo sbollentato, l'acqua, il sakè, la salsa di soia, il mirin e lo zucchero. Portare a leggero bollore. Cuocere a fuoco basso per 25 minuti, schiumando di tanto in tanto le impurità che affiorano in superficie. A metà cottura, dopo circa 12 minuti, girare il pollo. Al termine della cottura, togliere il pollo e l'alga kombu dalla pentola. Lasciare raffreddare il pollo e il brodo separatamente, poi trasferire il brodo in frigorifero per farlo diventare ben freddo. Preparare i condimenti: tagliare il pollo cotto a fettine sottili e condirlo con un pizzico di sale. Tritare finemente il myoga e le foglie di shiso. Cuocere i somen seguendo le istruzioni sulla confezione. Scolarli e passarli immediatamente in una ciotola con acqua fredda e ghiaccio per bloccare la cottura e renderli più sodi. Scolarli di nuovo molto bene. Prendere il brodo freddo dal frigorifero, aggiungere l'aceto e mescolare. Mettere i somen in una ciotola, versarvi sopra il brodo freddo e guarnire con il trito di myoga e shiso, le fettine di pollo e i germogli di ravanello."
   },
@@ -264,7 +284,15 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "nori",
       "soba"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "200g di soba",
+      "Cipolline verdi o negi",
+      "1 confezione di natto",
+      "katsuobushi",
+      "Kizami nori",
+      "1 uovo fresco che si possa mangiare crudo (opzionale)"
+    ],
     "instructionsText": "Bolli i soba in abbondante acqua (io non metto sale), sciacquali sotto l'acqua fredda, trasferiscili in una ciotola con acqua e ghiaccio per raffreddarli, scolali e asciugali bene, e mettili in una ciotola facendo una fossetta al centro, dove metterai il rosso dell'uovo. Aggiungi ai lati il natto, le cipolline tagliate sottili, il katsuobushi, il kizami nori, e il rosso dell'uovo al centro. Opzionale, come in foto, puoi aggiungere un paio di foglie di shiso fresco per guarnire. Mischia il mentsuyu e il dashi, per ottenere lo tsuyu, che verserai al lato della ciotola, per fare un fondo di circa 1 cm di altezza. E ora non ti resta che mangiare! Itadakimasu!"
   },
   "ricette/menrui/tori_dashi_no_nyumen": {
@@ -274,7 +302,18 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": "/img/ricette/tori-dashi-nyumen.jpg",
     "recipeCategory": "Noodles",
     "recipeKeywords": [],
-    "recipeIngredient": [],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "Ossa di pollo (circa 300-400g, come ali o carcasse)",
+      "3 litri d'acqua (divisi in due fasi)",
+      "Un pezzetto di zenzero fresco",
+      "Uno scarto di porro (parte verde o cuore)",
+      "30-40 ml di salsa di soia (shoyu)",
+      "1 cucchiaio di zucchero (opzionale)",
+      "Sale q.b.",
+      "2 porzioni di Somen",
+      "Cipollotto (negi) per guarnire"
+    ],
     "instructionsText": "Il segreto di questo piatto risiede nella pulizia accurata della materia prima. Iniziamo mettendo le ossa di pollo, preferibilmente spezzate per rilasciare più sapore, in una pentola con un litro e mezzo d'acqua. Portiamo a bollore e lasciamo cuocere per pochi minuti finché non affiorano tutte le impurità in superficie; a questo punto gettiamo l'acqua e sciacquiamo bene le ossa sotto acqua corrente. Rimettiamo le ossa pulite nella pentola con il restante litro e mezzo d'acqua fresca, aggiungendo lo zenzero, lo scarto del porro, la salsa di soia, un pizzico di sale e lo zucchero. Copriamo e lasciamo sobbollire a fiamma bassa per circa un'ora, filtrando poi il brodo ottenuto con un colino a maglie fini per renderlo limpido. Mentre il brodo riposa, cuociamo i somen in acqua bollente per circa 3 minuti. Una volta pronti, è fondamentale scolarli e sciacquarli immediatamente sotto acqua corrente fredda, strofinandoli per rimuovere l'amido, e concludere con un breve bagno in acqua e ghiaccio per fermare la cottura. Per servire, disponiamo i somen in una ciotola, versiamo il brodo di pollo bollente e completiamo con il cipollotto tritato finemente."
   },
   "ricette/menrui/tororo_natto_shiso_udon": {
@@ -291,6 +330,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "negi",
       "shoyu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Udon precotti",
       "1 confezione di Natto",
@@ -313,6 +353,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "kizami_nori",
       "nori"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 confezione di Udon precotti",
       "Una noce di Burro",
@@ -334,6 +375,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "katsuobushi",
       "beni_shoga"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Udon precotti",
       "80g di fettine di maiale (preferibilmente una parte grassa; i vegetariani possono sostituirlo con dei funghi shiitake)",
@@ -360,6 +402,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "katsuobushi",
       "shiitake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Pasta precotta a temperatura ambiente (ramen noodles o altra pasta)",
       "Salsa yakisoba circa 3-4 cucchiai",
@@ -384,7 +427,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "kizami_nori",
       "nori"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "200g di spaghetti di grano saraceno"
+    ],
     "instructionsText": "Bollire gli spaghetti in abbondante acqua senza sale per la durata suggerita sulla confezione. Scolarli conservando una tazza dell'acqua di cottura (sobayu). Usare un colino e sciacquarli sotto acqua corrente fredda con le mani per eliminare l'amido in eccesso. Trasferirli in una ciotola con acqua e ghiaccio per raffreddarli per circa 30 secondi, poi scolarli bene e metterli da parte."
   },
   "ricette/nimono/daikon_no_nimono": {
@@ -401,6 +447,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "vegan",
       "vegetarian"
     ],
+    "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Per iniziare, prendete un grosso daikon e privatelo delle estremità. Anche se la buccia può sembrare sottile, lo strato esterno è in realtà piuttosto coriaceo, quindi è fondamentale rimuoverlo interamente utilizzando la tecnica del katsuramuki, effettuando un taglio rotatorio con il coltello. Una volta pelato, tagliate il tubero in fette spesse circa 3-4 cm. Per evitare che le fette si sfaldino durante la lunga cottura, rifilate accuratamente gli spigoli di ogni disco seguendo la tecnica del mentori. Per favorire la penetrazione del calore e degli aromi, incidete una croce profonda un paio di centimetri su una delle basi di ogni fetta di daikon. Passate quindi alla fase di pre-cottura: mettete il daikon in una pentola e copritelo con l'acqua recuperata dal lavaggio del riso. Coprite con un otoshibuta e fate bollire per circa un'ora; l'amido contenuto nell'acqua del riso aiuterà a rimuovere l'amaro naturale della radice, rendendola dolcissima. Verificate la cottura con uno stuzzicandente: quando penetra la polpa senza resistenza, scolate il daikon e lavatelo delicatamente sotto acqua corrente. Rimettetelo sul fuoco coprendolo con acqua fresca, portate a bollore e sciacquatelo nuovamente. Questa doppia pulizia assicura un sapore pulito e delicato. Per la cottura finale, disponete le fette in una pentola e ricopritele interamente con del dashi. Aggiungete un cucchiaio di mirin e un paio di cucchiai di salsa di soia (shoyu). Posizionate nuovamente l'otoshibuta e lasciate sobbollire a fuoco dolce per circa mezz'ora. Al termine, spegnete la fiamma e lasciate riposare il daikon nel suo brodo fino a quando non si sarà raffreddato; questo passaggio è fondamentale affinché la radice assorba tutto l'umami del liquido. Mentre il daikon riposa, preparate il guarnimento affettando molto finemente della scorza di limone, avendo cura di prelevare solo la parte gialla. Potete servire il piatto sia freddo che caldo, accompagnandolo con il suo brodo di cottura e completando con le striscioline di limone. Se eseguito correttamente, il daikon risulterà così tenero da poter essere tagliato facilmente con le bacchette."
   },
@@ -415,6 +462,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Zucca (varietà Kabocha o Mantovana)",
       "Dashi (o Dashi Vegano) q.b.",
@@ -438,6 +486,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "negi",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 kg di pancetta di maiale",
       "1 Cipolla verde o un negi",
@@ -449,7 +498,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 pezzo di alga kombu",
       "4 uova"
     ],
-    "instructionsText": ""
+    "instructionsText": "Prima di tutto una premessa: questo è il metodo \"veloce\" per la preparazione del buta kaku-ni. Secondo il metodo tradizionale, spiegato ottimamente da Shizuo Tsuji nel suo libro \"Japanese Cooking: A Simple Art\" (praticamente la bibbia della cucina giapponese), ci vogliono due giorni per preparare il kakuni. Giuro che un giorno ci proverò, ma per ora mi accontento di questa versione. Tagliare la pancetta in pezzi di 5 cm di lato, e rosolare i cubi in una padella antiederente, 2 minuti per lato (12 minuti in totale). Asciugarli con un panno o dei fazzoletti di carta per eliminare il grasso in eccesso. Mettere i cubi di pancetta rosolata in una pentola a pressione, con il lato della pelle rivolto verso il basso. Aggiungere acqua tiepida ed un bicchiere di sake, fino a coprire la pancetta. Aggiungere la parte verde della cipolla e lo zenzero tagliato a fette. Chiudere la pentola a pressione e cuocere per mezz'ora. Scolare la pancetta e metterla da parte. Filtrare il brodo di cottura, facendolo freddare per poi togliere il grasso. Cuocere le uova in acqua bollente per 6 minuti e 30 secondi (prendendole dal frigo così partono sempre dalla stessa temperatura), in modo che restino liquide al centro, raffreddarle in acqua ghiacciata e sbucciarle. Sbollentare il bok choi in acqua bollente per 1 minuto, o saltarlo in padella con aglio e zenzero, e metterlo da parte. In una casseruola, mettere il brodo, la salsa di soia, il mirin, lo zucchero e il sake. Aggiungere la pancetta e il daikon tagliato a fette, e cuocere a fuoco basso facendo sobbollire per per 30 minuti. Negli ultimi 10 minuti aggiungere le uova e togliere il coperchio in modo che si ritiri un po' la salsa. Servire il kakuni con il bok choy e il daikon, e un po' di salsa. Guarnire a piacere con senape karashi, shichimi togarashi, e la parte bianca della cipolla verde tagliata a julienne e immersa in acqua fredda per arricciarla."
   },
   "ricette/nimono/nikujaga": {
     "docId": "ricette/nimono/nikujaga",
@@ -460,7 +509,18 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "mirin"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "4 persone",
+    "recipeIngredient": [
+      "300g di manzo (taglio sottile o straccetti)",
+      "2 patate grandi",
+      "1 carota grande",
+      "1 cipolla grande",
+      "Olio di semi q.b.",
+      "Dashi q.b. (circa 400-500ml, per coprire)",
+      "Mirin 3 cucchiai",
+      "Salsa di soia (Shoyu) 3 cucchiai",
+      "Taccole (opzionali, per guarnizione)"
+    ],
     "instructionsText": "La preparazione inizia con il taglio delle verdure, che in questo piatto deve essere piuttosto rustico ma curato. Tagliamo la carota e la cipolla a pezzettoni grossolani. La carne di manzo deve essere tagliata a straccetti o fettine sottili, ideali per una cottura in umido veloce che la mantenga morbida. Passiamo alle patate: dopo averle tagliate a pezzi grandi, è fondamentale eseguire il mentori. Con un pelapatate, rifiliamo tutti gli spigoli vivi di ogni pezzo di patata, smussandoli. Questa tecnica serve a evitare che la patata si sfaldi e si rompa durante la cottura nel liquido, mantenendo il brodo limpido e i pezzi integri. Per la cottura, l'ordine di inserimento degli ingredienti è importante. Scaldiamo un filo di olio di semi in una pentola capiente (o un tegame di ghisa) e inseriamo prima le patate, poi le cipolle. Rosoliamo le verdure insieme per qualche minuto per insaporirle. Solo a questo punto aggiungiamo la carne. Non cerchiamo una rosolatura aggressiva della carne, ma vogliamo cuocerla dolcemente affinché si sfaldi e diventi tenerissima in cottura. Una volta che la carne ha cambiato colore, uniamo le carote e copriamo tutto a filo con il dashi. Alziamo la fiamma al massimo e portiamo a bollore. Appena il liquido bolle, utilizziamo un colino a maglia fine per \"schiumare\" il brodo, rimuovendo tutte le impurità che affiorano in superficie. A questo punto condiamo aggiungendo un giro di mirin e di salsa di soia. Abbassiamo la fiamma al minimo e copriamo con un otoshibuta. Lasciamo cuocere dolcemente per circa 15 minuti. Trascorso questo tempo, spegniamo il fuoco e lasciamo riposare: è in questa fase che i sapori si amalgamano e le verdure assorbono il condimento. Mentre il Nikujaga riposa, possiamo sbollentare brevemente delle taccole in acqua salata: useremo il loro verde brillante come guarnizione decorativa per dare un tocco di colore al piatto finito."
   },
   "ricette/preparazioni_di_base/brodi/dashi": {
@@ -473,6 +533,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "katsuobushi",
       "kombu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1.8 litri di acqua fredda",
       "30 grammi di alga kombu",
@@ -492,6 +553,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "½ tazza di sake",
       "1 tazza abbondante di mirin (dice 1 ⅛ che dovrebbe essere 1 + 2 cucchiai)",
@@ -513,7 +575,12 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "kombu",
       "shiitake"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "circa 2 litri",
+    "recipeIngredient": [
+      "2 litri di Acqua",
+      "20-30g di Alga Kombu",
+      "5 Funghi Shiitake disidratati (secchi)"
+    ],
     "instructionsText": "La preparazione richiede tempo e pazienza per estrarre al meglio i sapori in modo delicato (infusione a freddo)."
   },
   "ricette/preparazioni_di_base/condimenti/furikake": {
@@ -528,6 +595,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "nori",
       "sesamo"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Katsuobushi",
       "Alga Kombu (anche recuperati dal dashi)",
@@ -546,6 +614,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 tazza e 1/2 di salsa di soia",
       "1 tazza di mirin",
@@ -563,6 +632,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "rice"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "3 cucchiai di ketchup",
       "2 cucchiai di salsa Worcestershire",
@@ -584,6 +654,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "yuzu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "2 parti di salsa di soia",
       "1 parte e ½ di dashi",
@@ -600,6 +671,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Salse",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [
       "3 cucchiai di salsa worcestershire",
       "1 cucchiaio di mentsuyu",
@@ -618,6 +690,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "daikon",
       "mirin"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "3 parti dashi",
       "1 parte mirin",
@@ -637,6 +710,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "potato_starch",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 parte di sake",
       "1 parte di mirin",
@@ -653,6 +727,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Salse",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [
       "4 cucchiai di ketchup (preferibilmente uno dal sapore poco zuccherino)",
       "4 cucchiai di salsa Worcestershire (in Giappone si usa una salsa simile, più fruttata, ma la Worcestershire classica è un’ottima alternativa)",
@@ -670,6 +745,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Salse",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [
       "2 cucchiai di Zucchero",
       "2 cucchiai di Ketchup",
@@ -689,6 +765,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 tazza di salsa di soia",
       "1  tazza di mirin",
@@ -707,6 +784,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Sushi",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Sciogliere completamente lo zucchero e il sale nell'aceto, aggiungere l'alga e lasciare riposare per 24 ore in frigorifero. Dopo 24 ore, filtrare e imbottigliare, ed e' pronto per l'uso."
   },
@@ -722,7 +800,18 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "sake"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "riso bianco",
+      "300 g di manzo, io uso il cappello del prete tagliato a macchina, e' meglio usare un taglio molto grasso",
+      "1/2 cipolla gialla",
+      "1 cipollina verde",
+      "Beni shoga per guarnire",
+      "150 ml di dashi",
+      "3-4 cucchiai di salsa di soia",
+      "2 cucchiai di mirin",
+      "2 cucchiai di sake"
+    ],
     "instructionsText": "Taglia la cipolla a fettine sottili per il lungo, e la cipollina verde a rondelle sottili. In una padella mmetti il dashi, la salsa di soia, il mirin e il sake e le cipolle, fai cuocere a fuoco medio fino a che le cipolle non si ammorbidiscono. Usa un coperchio per non far evaporare il brodo. Dopo 2-3 minuti aggiungi la carne e fai cuocere finche' la carne non e' piu' rosa. Quando la carne e' cotta, spegni il fuoco e aggiungi la cipollina verde. Versa il tutto sopra il riso caldo e guarnisci con beni shoga."
   },
   "ricette/riso/hamburger_don": {
@@ -734,7 +823,15 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "rice"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "1 persona",
+    "recipeIngredient": [
+      "Una ciotola di Riso caldo",
+      "150g di Carne macinata a piacere (manzo, maiale o mista)",
+      "1 Uovo",
+      "1/2 Cipolla",
+      "Sale e pepe q.b.",
+      "1 cucchiaio di Olio di semi"
+    ],
     "instructionsText": "Tritare finemente la cipolla. Scaldare l'olio di semi in una padella a fuoco medio. Aggiungere la cipolla e soffriggere finché non appassisce. Aggiungere la carne macinata mista, condire con sale e pepe. Continuare a cuocere, premendo la carne per rosolarla e sgranarla, finché non è ben cotta. Aggiungere il ketchup e la salsa Worcestershire e saltare per 1-2 minuti finché il liquido in eccesso non evapora. Creare tre incavi nel composto di carne. Rompere un uovo in ciascun incavo. Abbassare la fiamma e cuocere per circa 5 minuti, o finché le uova non raggiungono la cottura desiderata. Mettere il riso caldo nelle ciotole individuali e adagiarvi sopra il composto di carne e uova."
   },
   "ricette/riso/nira_shio_kombu_onigiri": {
@@ -751,6 +848,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "katsuobushi",
       "nori"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Riso bianco (ben caldo)",
       "Nira (erba aglina)",
@@ -773,7 +871,15 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "nori",
       "rice"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "2 onigiri",
+    "recipeIngredient": [
+      "1 tazza di Riso per sushi",
+      "1 tazza e un cicinino di più di acqua",
+      "120g di Tonno sott'olio (o al naturale)",
+      "3-4 cucchiai di Maionese (meglio la Kewpie)",
+      "Sale fino",
+      "2 Fogli di Alga Nori"
+    ],
     "instructionsText": "Sciacqua il riso sotto acqua fredda fino a che l'acqua non risulta limpida. Cuoci il riso con la quantità di acqua indicata, utilizzando una pentola con coperchio o una cuociriso. Una volta cotto, lascia riposare coperto per 10 minuti. Mentre il riso cuoce, prepariamo il ripieno. Scola il tonno molto accuratamente. In una ciotola, mescola il tonno con la maionese fino a ottenere un composto omogeneo e cremoso, ma non eccessivamente liquido. Puoi aggiungere un pizzico di pepe nero o meglio ancora di shichimi togarashi). Tieni una piccola ciotola d'acqua con un pizzico di sale. Bagna le mani con l'acqua salata: questo aiuterà a non far attaccare il riso e a condire l'esterno dell'onigiri. Prendi una porzione di riso cotto, grande piu o meno come una palla da tennis, e appiattiscila nel palmo della mano, creando una conca al centro. Metti un cucchiaio abbondante di ripieno di tonno e maionese nella conca. Copri il ripieno con il riso circostante e sigillalo completamente, poi modella il tutto con entrambe le mani nella classica forma triangolare, premendo delicatamente per compattare. Taglia i fogli di alga nori a strisce (circa 3-4 cm di larghezza). Avvolgi una striscia alla base dell'onigiri, lasciando le estremità rivolte verso l'esterno, per creare un pratico punto in cui afferrare lo snack senza toccare il riso."
   },
   "ricette/riso/onigiri_kimchi_asiago": {
@@ -786,6 +892,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "nori"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Riso bianco cotto al vapore (deve essere bello fumante)",
       "Kimchi",
@@ -807,7 +914,19 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "sake"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "1 persona",
+    "recipeIngredient": [
+      "riso bianco",
+      "2 uova grandi",
+      "60 ml dashi",
+      "30 ml di salsa di soia",
+      "60 ml di mirin",
+      "mezza cipolla bianca",
+      "2 cosce di pollo o quantita' equivalente del taglio che preferite",
+      "cipolline o negi o prezzemolo (meglio quello giapponese) per decorare",
+      "2 cucchiai di sake",
+      "olio di semi di arachide"
+    ],
     "instructionsText": "L'Oyakodon va fatto su una padellina monoporzione, perche' poi lo fai scivolare tutto direttamente sulla ciotola di riso (caldo) Taglia la cipolla a fettine secondo la lunghezza della cipolla, il pollo a cubetti, e le cipolline a rondelle o losanghe. Rompi le uova in una ciotolina, e mescolale delicatamente (senza sbatterle) con le bacchette. Marina il pollo nel sake per 20 minuti. Asciuga bene il pollo e fallo rosolare a fuoco basso girandolo una sola volta quando si e' dorato. Quando e' dorato da entrambi i lati, toglierlo dalla padellina e metterlo da parte. Versa il dashi, il mirin e la salsa di soia nel pentolino, accendi il fuoco, aggiungi le cipolle e fai sobollire a fuoco medio-basso per 4 minuti. A questo punto abbassa la fiamma, e aggiungi il pollo. Fai sobollire per altri 2 minuti, fin quando il pollo non e' completamente cotto e il brodo non si e' ristretto un po'. Alza il fuoco a medio, versa delicatamente 2/3 dell'uovo cercando di coprire tutto. Mischia il resto dell'uovo alle cipolline e mettilo da parte. Fai andare 30-40 secondi a fuoco medio, poi abbassa la fiamma e cuoci un altro minuto, il brodo non si deve essere asciugato. Mischia molto delicatamente, e versa il restante uovo con le cipolline. A questo punto, spegni pure la fiamma e fai cuocere con il calore residuo per un altro minuto. La ricetta originale (come piace a me) prevede che l'uovo resti mezzo crudo e bello bavoso. Trasferisci il contenuto del pentolino direttamente sul riso facendocelo scivolare sopra. Servire caldo."
   },
   "ricette/riso/soborodon": {
@@ -825,8 +944,40 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "pollo",
       "uova"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "Riso bianco cotto al vapore q.b.",
+      "2 uova",
+      "200g di carne macinata di pollo",
+      "1 cucchiaio di Mirin",
+      "1 cucchiaio di Sake",
+      "2 cucchiai di Salsa di soia (Shoyu)",
+      "Zenzero fresco (una piccola noce)",
+      "Piselli sbollentati (per guarnire)",
+      "Beni Shoga (zenzero rosso marinato) q.b.",
+      "Olio di semi q.b."
+    ],
     "instructionsText": "Iniziamo occupandoci delle uova, che andranno a formare la prima metà del nostro colorato mosaico. Rompiamo le uova in una ciotola, sbattiamole leggermente con le bacchette e versiamole in una padella scaldata con un filo d'olio. Dobbiamo strapazzarle in modo continuo e veloce, cercando di creare dei grumi piccoli e soffici, senza seccarle troppo. Una volta pronte, trasferiamole su un piatto e teniamole da parte. Nella stessa padella (non serve lavarla), inseriamo la carne macinata di pollo cruda. Aggiungiamo subito i condimenti: il mirin, il sake, la salsa di soia e lo zenzero fresco grattugiato. Accendiamo il fuoco e iniziamo a cuocere sgranando la carne in continuazione con una spatola di legno. Questo passaggio è fondamentale: la carne deve cuocersi sminuzzandosi il più possibile, assorbendo tutti i liquidi della marinatura. Continuiamo la cottura fino a quando il sughetto sul fondo non si sarà quasi completamente asciugato, lasciando il macinato saporito e ben sgranato. Ora arriva il momento più divertente: l'assemblaggio. Prepariamo una ciotola capiente creando una base soffice di riso bianco. Disponiamo le uova strapazzate su una metà della ciotola e il macinato di pollo sull'altra metà. Per separare queste due \"tifoserie\", creiamo una coreografica linea di demarcazione centrale utilizzando i piselli sbollentati. Infine, per dare un tocco di acidità che pulisce il palato e un accento di colore rosso vivo, adagiamo al centro un ciuffetto di beni shoga. Il vostro Soboro Don è pronto per essere ammirato e, soprattutto, divorato!"
+  },
+  "ricette/riso/takenoko_gohan": {
+    "docId": "ricette/riso/takenoko_gohan",
+    "title": "Takenoko Gohan",
+    "description": "Un classico primaverile: riso condito (Takikomi Gohan) cotto con germogli di bambù, aburaage e brodo dashi.",
+    "image": "/img/ricette/takenoko_gohan.jpg",
+    "recipeCategory": "Riso",
+    "recipeKeywords": [
+      "mirin",
+      "rice",
+      "shoyu"
+    ],
+    "recipeYield": "2 persone",
+    "recipeIngredient": [
+      "2 misurini di Riso (circa 300g)",
+      "120-150g di Germogli di bambù già bolliti",
+      "1 foglio piccolo di Aburaage (tofu fritto sottile)",
+      "Qualche foglia di Kinome (germogli di pepe sansho) per guarnire (opzionale)"
+    ],
+    "instructionsText": ""
   },
   "ricette/riso/takenoko_to_aburaage_takikomi_gohan": {
     "docId": "ricette/riso/takenoko_to_aburaage_takikomi_gohan",
@@ -841,6 +992,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sake",
       "negi"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 misurino di Riso bianco varietà originario",
       "Tofu fritto (Aburaage)",
@@ -865,7 +1017,17 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "shiitake"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "1 persona",
+    "recipeIngredient": [
+      "1 tazza di riso",
+      "1 cucchiaio di salsa di soia",
+      "1 cucchiaio di mirin",
+      "1 tazza di dashi",
+      "1 pizzico di sale (un cucchiaino piccolo? Da misurare)",
+      "3-4 shiitake",
+      "Mezza carota a julienne",
+      "pollo/tonno in scatola/varie ed eventuali"
+    ],
     "instructionsText": "Quando lavi il riso poi lascialo a bagno una mezz’ora e poi un quarto d’ora ad asciugare: assorbira’ meglio il condimento Metti gli shiitake a mollo nel dashi tiepido, dopo mezz’ora filtra il tutto, otterrai lo shiitake dashi. Nella risiera metti il riso, il sale (non te lo scordare, molto poco ma ci vuole) la soia e il mirin, lo shiitake dashi (deve essere della stessa quantita’ in volume del riso) e mischia bene, fai depositare il riso e poi sopra metti, a strati, gli ingredienti, dal più duro al piu’ morbido. Accendi la risiera e non toccare, gira solo quando ha finito, e vedrai che ti mangi."
   },
   "ricette/sides/bieta_gialla_ohitashi": {
@@ -875,6 +1037,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": "/img/ricette/bieta-ohitashi.jpg",
     "recipeCategory": "Contorni",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 mazzo di bieta gialla (facilmente reperibile anche in Italia)",
       "120 ml di Dashi (anche in versione vegana)",
@@ -895,6 +1058,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sides",
       "katsuobushi"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 testa di broccoli",
       "1 cucchiaio di olio di sesamo (facoltativo ma consigliato)",
@@ -915,6 +1079,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "shoyu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "2 mazzi di Spinaci",
       "1 cucchiaino colmo di Sale (per la bollitura)"
@@ -931,6 +1096,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesamo",
       "shiso"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "2 Melanzane grandi (circa 300g)",
       "5 foglie di Shiso",
@@ -950,6 +1116,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 confezione di Funghi Enoki",
       "2 cucchiai di Salsa di Soia",
@@ -971,6 +1138,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "vegetarian",
       "vegan"
     ],
+    "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Metti subito a scaldare il grill del forno Tagliare la melanzana in 2, e inciderla a losanga (profondità’ 4-5 mm) per farla cuocere più’ uniformemente Mettere le melanzane in una padella con poco olio (arachide o girasole) caldo, dal lato della pelle, e farle cuocere senza coperchio per 2-3 minuti, girarle e farle cuocere dall’altro lato per altri 2-3 minuti. Se sono molto spesse mettere il coperchio. Mettere le melanzane in una teglia e spennellarle con la glassatura di miso, finire la cottura in forno con il grill al massimo, per 5 minuti o finche non sono dorate Vacci piano col miso che senno’ ti vengono salate Guarnire con negi (o cipolline)"
   },
@@ -986,6 +1154,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "shiso"
     ],
+    "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Preparare il brodo di marinatura mescolando in una caraffa l'acqua, la salsa di soia, il mirin, lo zucchero, il dashi in polvere e lo zenzero grattugiato. Lavare e asciugare molto bene le melanzane. Rimuovere il picciolo e tagliarle a metà per il lungo. Con un coltello, incidere la superficie della buccia con tagli diagonali poco profondi, per favorire la cottura e l'assorbimento del sapore. Disporre le melanzane in una padella capiente. Spennellarle uniformemente su tutta la superficie (prima la buccia, poi la polpa) con i due cucchiai di olio. Cuocere a fuoco medio con la buccia rivolta verso il basso per circa 2-3 minuti. Girare le melanzane, abbassare la fiamma al minimo, coprire con un coperchio e cuocere lentamente finché la polpa non sarà tenera e ben dorata. Versare il brodo preparato direttamente nella padella sopra le melanzane. Alzare la fiamma a fuoco medio e portare a ebollizione. Appena il liquido bolle, spegnere immediatamente il fuoco. Trasferire con delicatezza le melanzane e tutto il loro brodo in un contenitore per alimenti. Lasciare raffreddare completamente a temperatura ambiente, dopodiché coprire e riporre in frigorifero a insaporire per almeno 3 ore. Servire le melanzane fredde, irrorandole con il loro brodo di marinatura e guarnendo a piacere con foglie di shiso tritate o katsuobushi."
   },
@@ -1002,6 +1171,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "mirin",
       "rice"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Patate a pasta gialla 1 kg",
       "Maionese Kewpie 250 ml circa (regolabili a piacere)",
@@ -1032,6 +1202,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sake",
       "sesamo"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 Melanzana",
       "Fecola di patate",
@@ -1057,6 +1228,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "rice",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "450g daikon",
       "1 peperoncino rosso secco",
@@ -1080,6 +1252,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesamo",
       "shoyu"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "500g di Daikon",
       "Sale (circa 2 cucchiai abbondanti per la spurgatura)",
@@ -1098,6 +1271,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Marinati",
     "recipeKeywords": [],
+    "recipeYield": null,
     "recipeIngredient": [
       "250g zenzero fresco",
       "1 cucchiaino di sale fino"
@@ -1113,6 +1287,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "senape_karashi"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 Cetriolo",
       "Sale q.b.",
@@ -1132,6 +1307,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "miso",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "150g miso chiaro",
       "25ml di sake",
@@ -1149,6 +1325,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [
       "rice"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 tazza di spicchi di aglio",
       "3/4 tazza di zucchero (a me sembra troppa)",
@@ -1170,6 +1347,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesamo",
       "shiitake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "250g di carne di maiale macinata, preferite un taglio grasso come il collo.",
       "500g di cavolo cinese",
@@ -1196,6 +1374,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "vegan",
       "nori"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Kirimochi (panetti di riso glutinoso essiccati)",
       "Salsa di soia (Shoyu)",
@@ -1214,6 +1393,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "potato_starch",
       "sake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "4 fettine di arista di maiale, sottili ma non troppo, meno di 1 cm",
       "fecola di patate per infarinare leggermente le fettine"
@@ -1227,7 +1407,14 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "image": null,
     "recipeCategory": "Griglia",
     "recipeKeywords": [],
-    "recipeIngredient": [],
+    "recipeYield": "1 persona",
+    "recipeIngredient": [
+      "1 sovracoscia di pollo (preferibilmente con la pelle)",
+      "3 cucchiai di Mirin",
+      "3 cucchiai di Sake",
+      "3 cucchiai di Salsa di soia (Shoyu)",
+      "Riso bianco al vapore come accompagnamento"
+    ],
     "instructionsText": "La chiave per un ottimo pollo teriyaki risiede nella gestione del calore e del grasso. Iniziamo disponendo la sovracoscia in un pentolino o una padella antiaderente ancora fredda, posizionandola con il lato della pelle verso il basso. Accendiamo il fuoco e lo regoliamo al minimo: il segreto è la lentezza. Lasciamo che il pollo rosoli dolcemente per circa 7-8 minuti; questo permetterà al grasso sottocutaneo di sciogliersi lentamente, rendendo la pelle croccante e sottile. Una volta che la pelle è ben dorata, giriamo il pollo e procediamo con la cottura dell'altro lato. Durante questa fase, è fondamentale utilizzare della carta assorbente per tamponare ed eliminare tutto il grasso in eccesso rilasciato dal pollo nella padella. Questo passaggio è cruciale per evitare che la salsa finale risulti untuosa. Continuiamo la cottura per altri 3-4 minuti fino a quando entrambi i lati saranno ben rosolati, quindi togliamo temporaneamente il pollo dalla padella e lasciamolo riposare. Prepariamo ora la salsa teriyaki nella stessa padella. Versiamo il mirin e il sake, alziamo leggermente la fiamma per far evaporare l'alcol e poi aggiungiamo la salsa di soia. Quando l'intruglio inizia a sobbollire, lasciamolo restringere per circa un minuto. Reintroduciamo il pollo nella padella e iniziamo a glassarlo con cura, girandolo più volte per farlo caramellare uniformemente su tutti i lati. Vogliamo che la salsa diventi splendente e affascinante, avvolgendo il pollo come una lacca. Infine, affettiamo il pollo a striscioline, come farebbe un vero chef di Hokuto, e disponiamolo coreograficamente su un letto di riso bianco al vapore. Non dimentichiamo di versare sopra tutta la salsa rimasta nella padella: sarebbe un delitto sprecarla."
   },
   "ricette/zuppe/misoshiru": {
@@ -1241,7 +1428,15 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "negi",
       "wakame"
     ],
-    "recipeIngredient": [],
+    "recipeYield": "1 porzione",
+    "recipeIngredient": [
+      "1 tazza di dashi",
+      "1 cucchiaio di miso",
+      "1 cucchiaino di wakame essiccato",
+      "tofu",
+      "negi o porro",
+      "altre aggiunte a piacere (opzionale)"
+    ],
     "instructionsText": "Portate il dashi a sfiorare il bollore. Se state preparando una zuppa di miso con verdure, funghi o altri ingredienti, aggiungeteli adesso e portateli a cottura prima del miso. Quando tutto è cotto, spegnete il fuoco e sciogliete il miso nel dashi aiutandovi con un setaccio o con un mestolino. Si può fare anche senza setaccio, ma in questo modo la zuppa resta più liscia e uniforme. Aggiungete il wakame, il tofu e il negi o il porro, poi servite subito."
   },
   "ricette/zuppe/osuimono": {
@@ -1256,6 +1451,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "sesame_oil",
       "sesamo"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Un pezzo di Daikon",
       "1 Carota piccola",
@@ -1276,6 +1472,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "potato_starch",
       "shiitake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Mezzo panetto di Tofu",
       "1 Uovo",
@@ -1290,6 +1487,39 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     ],
     "instructionsText": "Preparare il brodo di cottura mescolando in una ciotola il dashi, la salsa di soia, il mirin e lo zucchero. Tagliare le verdure: affettare le carote a julienne, tagliare le cipolline a tocchetti grossolani e affettare i funghi shiitake dopo aver rimosso il gambo. Tagliare il tofu a cubetti non troppo piccoli. Versare il brodo preparato in un pentolino e aggiungere subito i cubetti di tofu, facendo attenzione a non romperli. Coprire e scaldare a fuoco medio per circa 10 minuti, finché non inizia a bollire. Togliere delicatamente il tofu cotto dal pentolino e metterlo da parte in un piatto fondo. Versare tutte le verdure tagliate (carote, funghi e cipolline) nello stesso brodo di cottura, coprire e cuocere per circa 5 minuti. Nel frattempo, sbattere leggermente un uovo in una ciotolina. In un'altra piccola ciotola, sciogliere la fecola di patate con un paio di cucchiai d'acqua fredda. Trascorsi i 5 minuti, versare la fecola sciolta nel pentolino con le verdure e mescolare per addensare leggermente il brodo. Creare un vortice nel brodo e versare a filo l'uovo sbattuto per creare l'effetto \"stracciatella\". Versare le verdure e il brodo sopra il tofu messo da parte nel piatto. La ricetta è pronta, e daje!"
   },
+  "ricette/zuppe/tonjiru": {
+    "docId": "ricette/zuppe/tonjiru",
+    "title": "Tonjiru",
+    "description": "La zuppa giapponese più confortante, un \"reset dell'anima\" ricco di maiale e verdure di radice.",
+    "image": "/img/ricette/tonjiru.jpg",
+    "recipeCategory": "Zuppe",
+    "recipeKeywords": [
+      "daikon",
+      "konnyaku",
+      "miso",
+      "sesame_oil",
+      "sesamo"
+    ],
+    "recipeYield": "4 persone",
+    "recipeIngredient": [
+      "250g di Pancetta di maiale (tagliata sottile)",
+      "250g di Daikon",
+      "1 Carota",
+      "300g di Patate (una patata media)",
+      "In alternativa o insieme alla patata, 250g di Gobo",
+      "3 pezzi di Taro (Satoimo) (circa 250g)",
+      "1/2 blocco di Konnyaku",
+      "1 Cipolla media",
+      "1 Cipollotto (Negi)",
+      "1/2 panetto di Tofu (Momen o sodo)",
+      "800ml - 1 litro di Dashi",
+      "2-3 cucchiai di Miso (meglio il miso rosso, Aka miso)",
+      "1 cucchiaino di Zenzero grattugiato",
+      "1 cucchiaio di Olio di sesamo",
+      "Sale q.b."
+    ],
+    "instructionsText": ""
+  },
   "ricette/zuppe/vegan-misoshiru": {
     "docId": "ricette/zuppe/vegan-misoshiru",
     "title": "Zuppa di Miso Vegana",
@@ -1301,6 +1531,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "miso",
       "wakame"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "Dashi vegano (brodo di alga kombu e funghi shiitake)",
       "1 cucchiaio abbondante di Miso (nel video si usa il miso rosso o akamiso)",
@@ -1323,6 +1554,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "miso",
       "shiitake"
     ],
+    "recipeYield": null,
     "recipeIngredient": [
       "1 litro di Acqua fredda",
       "1-2 pezzi di Alga Kombu",

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * Swizzled da @docusaurus/theme-classic. Aggiunge <RecipeStructuredData />
+ * (schema JSON-LD Recipe) accanto al markdown della pagina, lasciando
+ * inalterato il rendering originale.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import Heading from '@theme/Heading';
+import MDXContent from '@theme/MDXContent';
+import type {Props} from '@theme/DocItem/Content';
+import RecipeStructuredData from '@site/src/components/RecipeStructuredData';
+
+function useSyntheticTitle(): string | null {
+  const {metadata, frontMatter, contentTitle} = useDoc();
+  const shouldRender =
+    !frontMatter.hide_title && typeof contentTitle === 'undefined';
+  if (!shouldRender) {
+    return null;
+  }
+  return metadata.title;
+}
+
+export default function DocItemContent({children}: Props): ReactNode {
+  const syntheticTitle = useSyntheticTitle();
+  return (
+    <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
+      <RecipeStructuredData />
+      {syntheticTitle && (
+        <header>
+          <Heading as="h1">{syntheticTitle}</Heading>
+        </header>
+      )}
+      <MDXContent>{children}</MDXContent>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fase **A4** del workplan SEO — l'item con **impatto massimo** per Google rich results (sez. 0.3 del workplan). Inietta schema `Recipe` JSON-LD nelle pagine ricetta, sbloccando i rich result Recipe e potenzialmente il carousel \"Ricette\" su Google.

**Strategia PoC**: per evitare di rilasciare schema malformato su 70+ pagine, A4 è inizialmente attiva solo su 2 ricette campione (`/ricette/dashi/` e `/ricette/kara-age/`). Una volta che il [Rich Results Test](https://search.google.com/test/rich-results) restituisce \"Recipe valida\" per entrambe, rimuoviamo il filtro `POC_PATHS` in un secondo commit per generalizzare a tutte.

## Pipeline tecnica

1. **`scripts/generate-recipe-data.js`** — nuovo prebuild script: walka `docs/ricette/**/*.md`, parsa frontmatter + body markdown, estrae prima sezione `Ingredienti` (h2/h3) e prima sezione `Preparazione` (con tolleranza per typo \"Preprarazione\"), pulisce link e admonitions. Output: `src/data/recipe-data.ts`.

2. **`src/components/RecipeStructuredData.tsx`** — componente che usa `useDoc()` per leggere il metadata della pagina, importa `RECIPE_DATA`, costruisce l'oggetto schema.org Recipe e lo inietta via `<Head>`. Filtro `POC_PATHS` per il PoC.

3. **`src/theme/DocItem/Content/index.tsx`** — swizzle minimale del template Content del DocItem: aggiunge `<RecipeStructuredData />` accanto al MDX render. Niente altri side-effect.

4. **`package.json`** — `prebuild` ora include `node scripts/generate-recipe-data.js`.

## Esempio schema generato

Per `/ricette/dashi/`:

```json
{
  \"@context\": \"https://schema.org\",
  \"@type\": \"Recipe\",
  \"name\": \"Dashi\",
  \"description\": \"il brodo base per moltissime ricette\",
  \"url\": \"https://paginegiappe.it/ricette/dashi/\",
  \"author\": {\"@type\": \"Person\", \"name\": \"Stefano Guglielmetti\", \"url\": \"https://paginegiappe.it/\"},
  \"image\": [\"https://paginegiappe.it/img/ricette/dashi.jpg\"],
  \"recipeCuisine\": \"Giapponese\",
  \"recipeCategory\": \"Brodi\",
  \"keywords\": \"katsuobushi, kombu, ricetta giapponese, cucina giapponese\",
  \"recipeIngredient\": [
    \"1.8 litri di acqua fredda\",
    \"30 grammi di alga kombu\",
    \"35 grammi di katsuobushi\"
  ],
  \"recipeInstructions\": [{
    \"@type\": \"HowToStep\",
    \"text\": \"Non togliere la polvere bianca dall'alga Kombu... [intero body della prima sezione Preparazione]\"
  }],
  \"dateModified\": \"2026-02-28T17:06:02.000Z\"
}
```

## Verifica build statico

| Pagina | `<script type=\"application/ld+json\">` | Schema injected |
|---|---|---|
| `/ricette/dashi/` | 2 | BreadcrumbList + Recipe ✓ |
| `/ricette/kara-age/` | 2 | BreadcrumbList + Recipe ✓ |
| `/ricette/gyoza/` (non-PoC) | 1 | solo BreadcrumbList — Recipe **NON** iniettato ✓ |
| `/ricette/teriyaki_chicken/` | 1 | solo BreadcrumbList ✓ |

Comportamento atteso: solo le 2 PoC pages hanno il Recipe schema.

## Cosa **manca** dal schema (non blocking)

Da aggiungere nelle fasi successive del workplan:
- `datePublished` — Google preferisce avere ANCHE quello, ma `dateModified` da solo è accettato (warning, non error)
- `prepTime` / `cookTime` / `totalTime` — opzionali per Google ma utili per rich result. Frontmatter delle ricette non li ha → workplan **A5 (frontmatter esteso)**
- `recipeYield` — idem, A5
- `video` (VideoObject) — molte ricette hanno YouTubeVideo embed, lo schema può linkarlo. Iter 2 di A4

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa, broken-link check pulito
- [x] `grep` su HTML build conferma 2 schema su PoC pages, 1 su altre
- [ ] **Validare con Rich Results Test su deploy preview Netlify**:
  - https://search.google.com/test/rich-results → URL del deploy preview di `/ricette/dashi/`
  - https://search.google.com/test/rich-results → URL del deploy preview di `/ricette/kara-age/`
  - Atteso: \"Ricetta\" valida con 0 errori (warning su prepTime/yield ammessi)
- [ ] Dopo OK del test → secondo commit per rimuovere `POC_PATHS` filter e generalizzare a tutte le 70 ricette
- [ ] Re-submit sitemap + \"Validate fix\" su GSC dopo merge

## Commit log

- `chore: fix typo "Preprarazione" -> "Preparazione" in kara-age`
- `seo(A4): Recipe JSON-LD schema su /ricette/* (PoC dashi+kara-age)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)