### PR TITLE
seo(A5): VideoObject nello schema Recipe per ricette con tutorial YouTube

### DIFF
--- a/scripts/generate-recipe-data.js
+++ b/scripts/generate-recipe-data.js
@@ -126,6 +126,14 @@ function categoryFromPath(filePath) {
   return CATEGORY_MAP[folder] ?? null;
 }
 
+/** Estrae tutti i videoId dai componenti `<YouTubeVideo videoId="..." />`. */
+function extractVideoIds(body) {
+  const ids = [];
+  const re = /<YouTubeVideo\s+videoId=["']([^"']+)["'][^>]*\/?>/g;
+  for (const m of body.matchAll(re)) ids.push(m[1]);
+  return ids;
+}
+
 function extractRecipe(filePath) {
   const raw = fs.readFileSync(filePath, 'utf-8');
   const {data: frontMatter, content: body} = matter(raw);
@@ -134,6 +142,7 @@ function extractRecipe(filePath) {
   if (frontMatter.draft === true) return null;
 
   const sections = parseSections(body);
+  const videoIds = extractVideoIds(body);
 
   // Prima sezione il cui titolo e' esattamente "Ingredienti" (case-insensitive).
   // Eventuali varianti tipo "Ingredienti per N persone" vanno rinominate nel
@@ -155,6 +164,7 @@ function extractRecipe(filePath) {
     recipeYield: typeof frontMatter.recipeYield === 'string' ? frontMatter.recipeYield : null,
     recipeIngredient,
     instructionsText,
+    videoIds,
   };
 }
 
@@ -170,7 +180,7 @@ function main() {
   for (const r of recipes) byId[r.docId] = r;
 
   // Output: file TS con const RECIPE_DATA.
-  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeYield: string | null;\n  recipeIngredient: string[];\n  instructionsText: string;\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
+  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeYield: string | null;\n  recipeIngredient: string[];\n  instructionsText: string;\n  videoIds: string[];\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
 
   const body = JSON.stringify(byId, null, 2);
 

--- a/scripts/generate-recipe-data.js
+++ b/scripts/generate-recipe-data.js
@@ -13,6 +13,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const {execSync} = require('child_process');
 const matter = require('gray-matter');
 
 const ROOT = process.cwd();
@@ -134,6 +135,25 @@ function extractVideoIds(body) {
   return ids;
 }
 
+/**
+ * Data del primo commit del file (proxy per "datePublished" dello schema).
+ * Usa --diff-filter=A --follow per beccare il commit di creazione anche
+ * dopo rinomine. Ritorna ISO 8601 string o null se non in git.
+ */
+function firstCommitDate(absFile) {
+  try {
+    const out = execSync(
+      `git log --diff-filter=A --follow --format='%aI' -- ${JSON.stringify(absFile)}`,
+      {encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore']},
+    ).trim();
+    if (!out) return null;
+    const lines = out.split('\n').filter(Boolean);
+    return lines[lines.length - 1] || null;
+  } catch {
+    return null;
+  }
+}
+
 function extractRecipe(filePath) {
   const raw = fs.readFileSync(filePath, 'utf-8');
   const {data: frontMatter, content: body} = matter(raw);
@@ -143,6 +163,7 @@ function extractRecipe(filePath) {
 
   const sections = parseSections(body);
   const videoIds = extractVideoIds(body);
+  const datePublished = firstCommitDate(filePath);
 
   // Prima sezione il cui titolo e' esattamente "Ingredienti" (case-insensitive).
   // Eventuali varianti tipo "Ingredienti per N persone" vanno rinominate nel
@@ -165,6 +186,7 @@ function extractRecipe(filePath) {
     recipeIngredient,
     instructionsText,
     videoIds,
+    datePublished,
   };
 }
 
@@ -180,7 +202,7 @@ function main() {
   for (const r of recipes) byId[r.docId] = r;
 
   // Output: file TS con const RECIPE_DATA.
-  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeYield: string | null;\n  recipeIngredient: string[];\n  instructionsText: string;\n  videoIds: string[];\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
+  const header = `// AUTO-GENERATED da scripts/generate-recipe-data.js — non editare a mano.\n// Estratto da docs/ricette/**/*.md. Rigenerato dal prebuild.\n\nexport interface RecipeData {\n  docId: string;\n  title: string;\n  description: string;\n  image: string | null;\n  recipeCategory: string | null;\n  recipeKeywords: string[];\n  recipeYield: string | null;\n  recipeIngredient: string[];\n  instructionsText: string;\n  videoIds: string[];\n  datePublished: string | null;\n}\n\nexport const RECIPE_DATA: Record<string, RecipeData> = `;
 
   const body = JSON.stringify(byId, null, 2);
 

--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -26,6 +26,29 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, '');
 }
 
+/**
+ * Costruisce un VideoObject schema.org riusando metadata della ricetta
+ * (name/description) e generando thumbnail YouTube + URL embed/content
+ * dal videoId. uploadDate non e' disponibile senza YouTube Data API,
+ * usiamo dateModified come fallback (Google lo accetta).
+ */
+function buildVideoObject(
+  videoId: string,
+  recipe: RecipeData,
+  uploadDate: string | undefined,
+): Record<string, unknown> {
+  const obj: Record<string, unknown> = {
+    '@type': 'VideoObject',
+    name: recipe.title,
+    description: recipe.description,
+    thumbnailUrl: [`https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`],
+    contentUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    embedUrl: `https://www.youtube.com/embed/${videoId}`,
+  };
+  if (uploadDate) obj.uploadDate = uploadDate;
+  return obj;
+}
+
 function buildRecipeSchema(
   data: RecipeData,
   permalink: string,
@@ -59,6 +82,9 @@ function buildRecipeSchema(
     ];
   }
   if (dateModified) schema.dateModified = dateModified;
+  if (data.videoIds.length > 0) {
+    schema.video = data.videoIds.map((id) => buildVideoObject(id, data, dateModified));
+  }
   return schema;
 }
 

--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -81,6 +81,7 @@ function buildRecipeSchema(
       },
     ];
   }
+  if (data.datePublished) schema.datePublished = data.datePublished;
   if (dateModified) schema.dateModified = dateModified;
   if (data.videoIds.length > 0) {
     schema.video = data.videoIds.map((id) => buildVideoObject(id, data, dateModified));

--- a/src/data/recipe-data.ts
+++ b/src/data/recipe-data.ts
@@ -11,6 +11,7 @@ export interface RecipeData {
   recipeYield: string | null;
   recipeIngredient: string[];
   instructionsText: string;
+  videoIds: string[];
 }
 
 export const RECIPE_DATA: Record<string, RecipeData> = {
@@ -37,7 +38,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "3 cucchiai di fecola di patate (katakuriko)",
       "Olio di semi per friggere q.b."
     ],
-    "instructionsText": "Iniziamo preparando i funghi enoki. È importante rimuovere la base (la parte terrosa), ma fate attenzione a non tagliare troppo in alto: i funghi devono rimanere uniti alla base per facilitare la frittura e mantenere la forma a ventaglio. Una volta puliti, dividete il mazzo in circa 8 piccoli mazzetti. Prendete un sacchetto per alimenti in plastica (tipo quelli per il gelo) e inserite i mazzetti di enoki insieme alla salsa di soia (o yakiniku), alla maionese, allo zenzero e all'aglio. Chiudete il sacchetto e massaggiate delicatamente affinché la marinatura penetri bene tra le fibre dei funghi. Lasciate riposare per circa 10 minuti in modo che i sapori vengano assorbiti. Passato il tempo di marinatura, scolate i funghi dal liquido in eccesso e trasferiteli in un nuovo sacchetto pulito. Aggiungete i semi di sesamo e la fecola di patate. Il segreto per una panatura perfetta è aggiungere la fecola un cucchiaio alla volta, scuotendo bene il sacchetto per distribuirla uniformemente su ogni mazzetto. In una padella antiaderente, scaldate una piccola quantità di olio di semi a fuoco medio. Quando l'olio è ben caldo, adagiate i mazzetti di enoki ben distanziati tra loro. Friggete finché non raggiungono un bel colore dorato e una consistenza croccante su entrambi i lati."
+    "instructionsText": "Iniziamo preparando i funghi enoki. È importante rimuovere la base (la parte terrosa), ma fate attenzione a non tagliare troppo in alto: i funghi devono rimanere uniti alla base per facilitare la frittura e mantenere la forma a ventaglio. Una volta puliti, dividete il mazzo in circa 8 piccoli mazzetti. Prendete un sacchetto per alimenti in plastica (tipo quelli per il gelo) e inserite i mazzetti di enoki insieme alla salsa di soia (o yakiniku), alla maionese, allo zenzero e all'aglio. Chiudete il sacchetto e massaggiate delicatamente affinché la marinatura penetri bene tra le fibre dei funghi. Lasciate riposare per circa 10 minuti in modo che i sapori vengano assorbiti. Passato il tempo di marinatura, scolate i funghi dal liquido in eccesso e trasferiteli in un nuovo sacchetto pulito. Aggiungete i semi di sesamo e la fecola di patate. Il segreto per una panatura perfetta è aggiungere la fecola un cucchiaio alla volta, scuotendo bene il sacchetto per distribuirla uniformemente su ogni mazzetto. In una padella antiaderente, scaldate una piccola quantità di olio di semi a fuoco medio. Quando l'olio è ben caldo, adagiate i mazzetti di enoki ben distanziati tra loro. Friggete finché non raggiungono un bel colore dorato e una consistenza croccante su entrambi i lati.",
+    "videoIds": [
+      "uK4SKPruJSI"
+    ]
   },
   "ricette/agemono/kara-age": {
     "docId": "ricette/agemono/kara-age",
@@ -62,7 +66,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Fecola di patate per infarinare",
       "Olio per friggere (arachide o girasole o canola)"
     ],
-    "instructionsText": "Tagliare il pollo in cubetti di circa 4 centimetri di lato, l'importante è che siano tutti più o meno delle stesse dimensioni, così che si cuociano uniformemente, meglio pezzi un po' piu cicciottelli che restano piu' umidi e danno piu' gusto. Preparare la marinatura, unendo mirin, sake, salsa di soia, e zenzero e aglio grattugiati (o spremuti brutalmente con uno schiaccia aglio). Mettere tutto in una ciotola, coprire con la pellicola e lasciar marinare in frigo per minimo 2 ore, anche se 24 ore e' l'ideale. Dopo la marinatura, infarinare il pollo nella fecola di patate, senza lasciare zone scoperte. Cercare di rimuovere tutta la farina in eccesso, facendo una infarinatura uniforme e leggera. Scaldare l’olio a 160 gradi e friggere una volta (4-5 pezzetti di pollo alla volta, in modo che non si attacchino tra di loro) per circa 90-120 secondi a seconda delle dimensioni del pollo. Lasciare scolare e riposare il pollo per qualche minuto, poi friggere nuovamente, questa volta a 180 gradi per circa 45 secondi - 1 minuto. Di nuovo far asciugare su una griglia, e gustare con la salsa (io uso Maionese Kewpie condita con lo shichimi togarashi). In alternativa, come facciamo anche noi con i fritti, potete gustarlo con una fettina di limone spremuta."
+    "instructionsText": "Tagliare il pollo in cubetti di circa 4 centimetri di lato, l'importante è che siano tutti più o meno delle stesse dimensioni, così che si cuociano uniformemente, meglio pezzi un po' piu cicciottelli che restano piu' umidi e danno piu' gusto. Preparare la marinatura, unendo mirin, sake, salsa di soia, e zenzero e aglio grattugiati (o spremuti brutalmente con uno schiaccia aglio). Mettere tutto in una ciotola, coprire con la pellicola e lasciar marinare in frigo per minimo 2 ore, anche se 24 ore e' l'ideale. Dopo la marinatura, infarinare il pollo nella fecola di patate, senza lasciare zone scoperte. Cercare di rimuovere tutta la farina in eccesso, facendo una infarinatura uniforme e leggera. Scaldare l’olio a 160 gradi e friggere una volta (4-5 pezzetti di pollo alla volta, in modo che non si attacchino tra di loro) per circa 90-120 secondi a seconda delle dimensioni del pollo. Lasciare scolare e riposare il pollo per qualche minuto, poi friggere nuovamente, questa volta a 180 gradi per circa 45 secondi - 1 minuto. Di nuovo far asciugare su una griglia, e gustare con la salsa (io uso Maionese Kewpie condita con lo shichimi togarashi). In alternativa, come facciamo anche noi con i fritti, potete gustarlo con una fettina di limone spremuta.",
+    "videoIds": [
+      "7VbEkKBAs-g"
+    ]
   },
   "ricette/antipasti/chawanmushi": {
     "docId": "ricette/antipasti/chawanmushi",
@@ -85,7 +92,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "20 ml di sake (opzionale)",
       "un pizzico di sale"
     ],
-    "instructionsText": "Unire in una ciotola le uova, con il dashi, il mirin, la salsa di soia (se si vuole, il sake) e il sale. Mescolare bene con luna frusta, cercando di non incorporare aria. Setacciare il composto con un colino a maglie strette in un'altra ciotola, e versare il composto nelle ciotoline di ceramica. Mettere nelle ciotoline uno o due gamberi, un paio di ginnan, e un fungo shiitake fatto a fettine. Versare il composto nelle ciotoline, e coprire con un foglio di alluminio. Mettere le ciotoline nella pentola per il vapore, e cuocere a circa 90 gradi per 10 minuti. La cosa piu' semplice per mantenere la temperatura é mettere una bacchetta tra il coperchio e la pentola, per tenere il coperchio socchiuso. Tenere la fiamma appena sufficiente a far sobbollire l'acqua. A questo punto si possono aggiungere altre decorazioni, come l'edamame, o un gambero o delle capesante fatte a fettine, e cuocere per altri 2 minuti. Altrimenti, si puo' cuocere per 12-13 minuti senza aggiungere nulla. Spegnere il fuoco, e lasciare riposare per 7-8 minuti. A questo punto aggiungere un po' di prezzemolo o cipolline, e servire caldo. Alternativamente, si puo' mettere in frigorifero e gustare freddo, con del buon vino bianco o del sake."
+    "instructionsText": "Unire in una ciotola le uova, con il dashi, il mirin, la salsa di soia (se si vuole, il sake) e il sale. Mescolare bene con luna frusta, cercando di non incorporare aria. Setacciare il composto con un colino a maglie strette in un'altra ciotola, e versare il composto nelle ciotoline di ceramica. Mettere nelle ciotoline uno o due gamberi, un paio di ginnan, e un fungo shiitake fatto a fettine. Versare il composto nelle ciotoline, e coprire con un foglio di alluminio. Mettere le ciotoline nella pentola per il vapore, e cuocere a circa 90 gradi per 10 minuti. La cosa piu' semplice per mantenere la temperatura é mettere una bacchetta tra il coperchio e la pentola, per tenere il coperchio socchiuso. Tenere la fiamma appena sufficiente a far sobbollire l'acqua. A questo punto si possono aggiungere altre decorazioni, come l'edamame, o un gambero o delle capesante fatte a fettine, e cuocere per altri 2 minuti. Altrimenti, si puo' cuocere per 12-13 minuti senza aggiungere nulla. Spegnere il fuoco, e lasciare riposare per 7-8 minuti. A questo punto aggiungere un po' di prezzemolo o cipolline, e servire caldo. Alternativamente, si puo' mettere in frigorifero e gustare freddo, con del buon vino bianco o del sake.",
+    "videoIds": [
+      "koIokEwbbMQ"
+    ]
   },
   "ricette/antipasti/hiyashi_nasu": {
     "docId": "ricette/antipasti/hiyashi_nasu",
@@ -103,7 +113,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Salsa di soia",
       "Katsuobushi"
     ],
-    "instructionsText": "Sbucciare completamente la melanzana con un pelapatate. Avvolgerla poi molto stretta in un foglio di carta da cucina. Passare la melanzana avvolta sotto l'acqua corrente, bagnando uniformemente la carta. Strizzarla bene per eliminare l'acqua in eccesso. Avvolgere nuovamente il tutto, ben stretto, con della pellicola per alimenti adatta al microonde. Cuocere la melanzana nel microonde per 3 minuti alla massima potenza. Questo metodo è una scorciatoia per la classica cottura al vapore. Appena finita la cottura, scartare immediatamente la melanzana dalla pellicola e dalla carta. Lasciarla raffreddare prima a temperatura ambiente, poi metterla in un contenitore e trasferirla in frigorifero finché non sarà completamente fredda. Prendere la melanzana fredda dal frigo e tagliarla a fette o a tocchetti. Disporla su un piattino. Guarnire con le cipolline affettate finemente, condire con un po' di salsa di soia e completare con una generosa manciata di katsuobushi. Provate assolutamente a rifarlo perché è veramente buono, buono, buono. Itadakimasu!"
+    "instructionsText": "Sbucciare completamente la melanzana con un pelapatate. Avvolgerla poi molto stretta in un foglio di carta da cucina. Passare la melanzana avvolta sotto l'acqua corrente, bagnando uniformemente la carta. Strizzarla bene per eliminare l'acqua in eccesso. Avvolgere nuovamente il tutto, ben stretto, con della pellicola per alimenti adatta al microonde. Cuocere la melanzana nel microonde per 3 minuti alla massima potenza. Questo metodo è una scorciatoia per la classica cottura al vapore. Appena finita la cottura, scartare immediatamente la melanzana dalla pellicola e dalla carta. Lasciarla raffreddare prima a temperatura ambiente, poi metterla in un contenitore e trasferirla in frigorifero finché non sarà completamente fredda. Prendere la melanzana fredda dal frigo e tagliarla a fette o a tocchetti. Disporla su un piattino. Guarnire con le cipolline affettate finemente, condire con un po' di salsa di soia e completare con una generosa manciata di katsuobushi. Provate assolutamente a rifarlo perché è veramente buono, buono, buono. Itadakimasu!",
+    "videoIds": []
   },
   "ricette/antipasti/hiyayakko": {
     "docId": "ricette/antipasti/hiyayakko",
@@ -123,7 +134,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Zenzero, grattugiato fresco",
       "Cipollina verde o negi affettata sottilmente"
     ],
-    "instructionsText": "Togli il tofu dalla confezione e scolalo delicatamente. Se ha molta acqua, lascialo riposare qualche minuto su carta da cucina per farlo asciugare leggermente, senza romperlo. Taglialo in 2 o 4 pezzi, oppure lascialo intero se lo servi in una sola porzione, e mettilo in una ciotolina o piattino fondo. Versa sopra la salsa ponzu, quanto basta per condirlo ma senza affogarlo. Guarnisci con una grattugiata di zenzero fresco, katsuobushi a piacere, e cipollina verde affettata."
+    "instructionsText": "Togli il tofu dalla confezione e scolalo delicatamente. Se ha molta acqua, lascialo riposare qualche minuto su carta da cucina per farlo asciugare leggermente, senza romperlo. Taglialo in 2 o 4 pezzi, oppure lascialo intero se lo servi in una sola porzione, e mettilo in una ciotolina o piattino fondo. Versa sopra la salsa ponzu, quanto basta per condirlo ma senza affogarlo. Guarnisci con una grattugiata di zenzero fresco, katsuobushi a piacere, e cipollina verde affettata.",
+    "videoIds": [
+      "LkaGIe4oocQ"
+    ]
   },
   "ricette/antipasti/nama_harumaki": {
     "docId": "ricette/antipasti/nama_harumaki",
@@ -144,7 +158,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Foglie di senape Mizuna (o in alternativa della comune insalata riccia)",
       "Maionese Kewpie"
     ],
-    "instructionsText": "Per il ripieno, iniziamo dalla preparazione del pollo. In questa ricetta utilizziamo delle alette, pre-cuocendole per una decina di minuti in friggitrice ad aria a 160 gradi. Una volta cotte, priviamole delle ossa sfilacciando la carne grossolanamente con le mani. Trasferiamo il pollo sfilacciato in una padella ben calda e versiamo la nostra salsa teriyaki, lasciando sfrigolare e caramellare i pezzetti di carne fino a renderli lucidi, appiccicosi e irresistibili. Passiamo alle verdure. Mondiamo la carota e la tagliamo a bastoncini sottili e regolari (hosogiri). Laviamo accuratamente le foglie di mizuna, una senape giapponese dal sapore leggermente pungente; se non riuscite a trovarla, una normalissima insalata riccia andrà benissimo per replicare la croccantezza necessaria. A questo punto prepariamo la postazione per l'assemblaggio. Prendiamo un foglio di carta di riso e lo inumidiamo delicatamente su ambo i lati con dell'acqua per farlo ammorbidire. Lo stendiamo sul tagliere e iniziamo a comporre il nostro involtino: posizioniamo prima un letto di foglie di mizuna, aggiungiamo una generosa e voluttuosa striscia di maionese Kewpie, adagiamo il pollo teriyaki caramellato e completiamo con i bastoncini di carota. Ora arriva il momento di mettere in pratica la memoria muscolare per chiudere l'involtino. Solleviamo il lembo inferiore della carta di riso coprendo il ripieno e stringendo bene con le dita. Ripieghiamo i bordi laterali verso l'interno per sigillare i lati, dopodiché continuiamo ad arrotolare l'involtino su se stesso esercitando una leggera pressione, fino a chiuderlo completamente in un cilindro compatto. I nostri Nama Harumaki sono pronti da tagliare a metà e gustare, tanto belli da vedere quanto buoni da mangiare."
+    "instructionsText": "Per il ripieno, iniziamo dalla preparazione del pollo. In questa ricetta utilizziamo delle alette, pre-cuocendole per una decina di minuti in friggitrice ad aria a 160 gradi. Una volta cotte, priviamole delle ossa sfilacciando la carne grossolanamente con le mani. Trasferiamo il pollo sfilacciato in una padella ben calda e versiamo la nostra salsa teriyaki, lasciando sfrigolare e caramellare i pezzetti di carne fino a renderli lucidi, appiccicosi e irresistibili. Passiamo alle verdure. Mondiamo la carota e la tagliamo a bastoncini sottili e regolari (hosogiri). Laviamo accuratamente le foglie di mizuna, una senape giapponese dal sapore leggermente pungente; se non riuscite a trovarla, una normalissima insalata riccia andrà benissimo per replicare la croccantezza necessaria. A questo punto prepariamo la postazione per l'assemblaggio. Prendiamo un foglio di carta di riso e lo inumidiamo delicatamente su ambo i lati con dell'acqua per farlo ammorbidire. Lo stendiamo sul tagliere e iniziamo a comporre il nostro involtino: posizioniamo prima un letto di foglie di mizuna, aggiungiamo una generosa e voluttuosa striscia di maionese Kewpie, adagiamo il pollo teriyaki caramellato e completiamo con i bastoncini di carota. Ora arriva il momento di mettere in pratica la memoria muscolare per chiudere l'involtino. Solleviamo il lembo inferiore della carta di riso coprendo il ripieno e stringendo bene con le dita. Ripieghiamo i bordi laterali verso l'interno per sigillare i lati, dopodiché continuiamo ad arrotolare l'involtino su se stesso esercitando una leggera pressione, fino a chiuderlo completamente in un cilindro compatto. I nostri Nama Harumaki sono pronti da tagliare a metà e gustare, tanto belli da vedere quanto buoni da mangiare.",
+    "videoIds": [
+      "Ls_tcuHzqkQ"
+    ]
   },
   "ricette/antipasti/sunomono": {
     "docId": "ricette/antipasti/sunomono",
@@ -168,7 +185,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Semi di sesamo tostati",
       "Sale fino"
     ],
-    "instructionsText": ""
+    "instructionsText": "",
+    "videoIds": []
   },
   "ricette/antipasti/yamitsuki_kyabesu": {
     "docId": "ricette/antipasti/yamitsuki_kyabesu",
@@ -189,7 +207,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di Sale",
       "1 cucchiaino di Brodo vegetale in polvere (in sostituzione del Kombucha in polvere)"
     ],
-    "instructionsText": "Prendere un contenitore di plastica con coperchio. Tagliare il cavolo cappuccio a quadratoni grossolani, senza essere troppo precisi, e separare le foglie con le mani. Mettere il cavolo tagliato nel contenitore. Aggiungere direttamente sul cavolo un cucchiaio di olio di sesamo, il brodo granulare, il sale e una generosa manciata di semi di sesamo. Chiudere il contenitore con il suo coperchio. Adesso arriva la parte divertente: shakerare fortissimo per qualche secondo, in modo da distribuire uniformemente il condimento e ammorbidire leggermente il cavolo. Aprire, trasferire in una ciotola e servire subito. È già pronta."
+    "instructionsText": "Prendere un contenitore di plastica con coperchio. Tagliare il cavolo cappuccio a quadratoni grossolani, senza essere troppo precisi, e separare le foglie con le mani. Mettere il cavolo tagliato nel contenitore. Aggiungere direttamente sul cavolo un cucchiaio di olio di sesamo, il brodo granulare, il sale e una generosa manciata di semi di sesamo. Chiudere il contenitore con il suo coperchio. Adesso arriva la parte divertente: shakerare fortissimo per qualche secondo, in modo da distribuire uniformemente il condimento e ammorbidire leggermente il cavolo. Aprire, trasferire in una ciotola e servire subito. È già pronta.",
+    "videoIds": []
   },
   "ricette/fish/sudako_negi_vapore": {
     "docId": "ricette/fish/sudako_negi_vapore",
@@ -208,7 +227,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale abbondante per la pulizia",
       "Pepe nero"
     ],
-    "instructionsText": "Metti i moscardini in una ciotola di terracotta (o una ciotola capiente). Aggiungi abbondante sale e massaggiali con cura ed energia. Fallo finché non ti sembra di star esagerando: quella è la quantità giusta di frizione. Sciacquali molto bene sotto l'acqua corrente per rimuovere tutto il sale e le impurità. Porta a bollore una pentola d'acqua e aggiungi sale. Immergi i moscardini tenendoli per la testa e bagnando prima solo le punte dei tentacoli ripetutamente (\"choi choi\"). Facendo così, i tentacoli si arricceranno verso l'esterno e prenderanno una bella forma una volta cotti. Quando la testa diventa dura e compatta al tatto, sono pronti. Scolali. Prendi il negi e taglialo diagonalmente a pezzi grossolani. Mettili in un cestello per la cottura al vapore e cuocili finché non diventano teneri e dolci. Nel frattempo prepara la salsa: in un pentolino metti un cucchiaio di zucchero e il doppio della quantità di aceto. Scalda leggermente solo per far sciogliere lo zucchero. Lascia raffreddare e aggiungi una piccolissima quantità di shoyu. Taglia i moscardini bolliti a pezzi facili da mangiare (la tecnica di taglio dipende dai gusti). Impiattamento: disponi il negi cotto al vapore sul fondo del piatto, spargi sopra i pezzi di moscardino. Condisci versando la salsa agrodolce (amazu) e completa con una spolverata di pepe nero. Itadakimasu!"
+    "instructionsText": "Metti i moscardini in una ciotola di terracotta (o una ciotola capiente). Aggiungi abbondante sale e massaggiali con cura ed energia. Fallo finché non ti sembra di star esagerando: quella è la quantità giusta di frizione. Sciacquali molto bene sotto l'acqua corrente per rimuovere tutto il sale e le impurità. Porta a bollore una pentola d'acqua e aggiungi sale. Immergi i moscardini tenendoli per la testa e bagnando prima solo le punte dei tentacoli ripetutamente (\"choi choi\"). Facendo così, i tentacoli si arricceranno verso l'esterno e prenderanno una bella forma una volta cotti. Quando la testa diventa dura e compatta al tatto, sono pronti. Scolali. Prendi il negi e taglialo diagonalmente a pezzi grossolani. Mettili in un cestello per la cottura al vapore e cuocili finché non diventano teneri e dolci. Nel frattempo prepara la salsa: in un pentolino metti un cucchiaio di zucchero e il doppio della quantità di aceto. Scalda leggermente solo per far sciogliere lo zucchero. Lascia raffreddare e aggiungi una piccolissima quantità di shoyu. Taglia i moscardini bolliti a pezzi facili da mangiare (la tecnica di taglio dipende dai gusti). Impiattamento: disponi il negi cotto al vapore sul fondo del piatto, spargi sopra i pezzi di moscardino. Condisci versando la salsa agrodolce (amazu) e completa con una spolverata di pepe nero. Itadakimasu!",
+    "videoIds": []
   },
   "ricette/fish/teriyaki_salmon": {
     "docId": "ricette/fish/teriyaki_salmon",
@@ -229,7 +249,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di sake",
       "Salsa Teriyaki"
     ],
-    "instructionsText": "Condire il salmone con sale e pepe nero appena macinato, poi passarlo leggermente nella farina bianca. Scaldare l'olio da cucina o il burro in una padella e cuocere il salmone per 3 minuti da un lato fino a doratura. Girare il salmone, aggiungere 1 cucchiaio di sake e coprire la padella per cuocere per altri 3 minuti. Rimuovere il coperchio, versare la salsa Teriyaki e cospargere il salmone con la salsa per ricoprirlo uniformemente."
+    "instructionsText": "Condire il salmone con sale e pepe nero appena macinato, poi passarlo leggermente nella farina bianca. Scaldare l'olio da cucina o il burro in una padella e cuocere il salmone per 3 minuti da un lato fino a doratura. Girare il salmone, aggiungere 1 cucchiaio di sake e coprire la padella per cuocere per altri 3 minuti. Rimuovere il coperchio, versare la salsa Teriyaki e cospargere il salmone con la salsa per ricoprirlo uniformemente.",
+    "videoIds": []
   },
   "ricette/menrui/bukkake_udon": {
     "docId": "ricette/menrui/bukkake_udon",
@@ -252,7 +273,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Un paio di cucchiaini di Salsa di Soia",
       "Acqua e ghiaccio"
     ],
-    "instructionsText": "I Condimenti: Per prima cosa prepariamo i topping. Prendiamo il nostro Daikon, lo spelliamo e lo grattugiamo. Strizziamolo leggermente per fargli perdere l'acqua in eccesso e teniamolo da parte. Già che ci siamo, andiamo ad affettare finemente anche qualche cipollina. Lo Zenzero: Dopodiché, peliamo un po' di zenzero con il metodo del cucchiaio (che è infallibile), lo grattugiamo e lo mettiamo da parte. Il Brodo (la parte \"Bukkake\"): \"Sì, ma in tutto questo bukkake che c'entra?\" direte voi. Tranquilli, ci arriveremo. In una ciotola mescoliamo il Dashi, un cucchiaio di Mentsuyu e un paio di cucchiaini di salsa di soia. Cottura degli Udon: Nel frattempo, mettiamo a bollire un pentolino d'acqua e, quando bolle, plop, ci mettiamo dentro i nostri udon preconfezionati. Basterà un paio di minuti di cottura. Raffreddamento: Appena cotti, li scoliamo e li facciamo raffreddare direttamente in una ciotola con acqua e ghiaccio. Poi, mi raccomando, scolateli molto bene."
+    "instructionsText": "I Condimenti: Per prima cosa prepariamo i topping. Prendiamo il nostro Daikon, lo spelliamo e lo grattugiamo. Strizziamolo leggermente per fargli perdere l'acqua in eccesso e teniamolo da parte. Già che ci siamo, andiamo ad affettare finemente anche qualche cipollina. Lo Zenzero: Dopodiché, peliamo un po' di zenzero con il metodo del cucchiaio (che è infallibile), lo grattugiamo e lo mettiamo da parte. Il Brodo (la parte \"Bukkake\"): \"Sì, ma in tutto questo bukkake che c'entra?\" direte voi. Tranquilli, ci arriveremo. In una ciotola mescoliamo il Dashi, un cucchiaio di Mentsuyu e un paio di cucchiaini di salsa di soia. Cottura degli Udon: Nel frattempo, mettiamo a bollire un pentolino d'acqua e, quando bolle, plop, ci mettiamo dentro i nostri udon preconfezionati. Basterà un paio di minuti di cottura. Raffreddamento: Appena cotti, li scoliamo e li facciamo raffreddare direttamente in una ciotola con acqua e ghiaccio. Poi, mi raccomando, scolateli molto bene.",
+    "videoIds": []
   },
   "ricette/menrui/hiyashi_tori_dashi_somen": {
     "docId": "ricette/menrui/hiyashi_tori_dashi_somen",
@@ -268,7 +290,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     ],
     "recipeYield": null,
     "recipeIngredient": [],
-    "instructionsText": "Sbollentare la sovraccoscia di pollo in acqua bollente per un minuto, quindi scolarla e gettare l'acqua. Questo passaggio serve a pulire il pollo e a garantire un brodo più limpido. In una pentola, unire l'alga kombu, il pollo sbollentato, l'acqua, il sakè, la salsa di soia, il mirin e lo zucchero. Portare a leggero bollore. Cuocere a fuoco basso per 25 minuti, schiumando di tanto in tanto le impurità che affiorano in superficie. A metà cottura, dopo circa 12 minuti, girare il pollo. Al termine della cottura, togliere il pollo e l'alga kombu dalla pentola. Lasciare raffreddare il pollo e il brodo separatamente, poi trasferire il brodo in frigorifero per farlo diventare ben freddo. Preparare i condimenti: tagliare il pollo cotto a fettine sottili e condirlo con un pizzico di sale. Tritare finemente il myoga e le foglie di shiso. Cuocere i somen seguendo le istruzioni sulla confezione. Scolarli e passarli immediatamente in una ciotola con acqua fredda e ghiaccio per bloccare la cottura e renderli più sodi. Scolarli di nuovo molto bene. Prendere il brodo freddo dal frigorifero, aggiungere l'aceto e mescolare. Mettere i somen in una ciotola, versarvi sopra il brodo freddo e guarnire con il trito di myoga e shiso, le fettine di pollo e i germogli di ravanello."
+    "instructionsText": "Sbollentare la sovraccoscia di pollo in acqua bollente per un minuto, quindi scolarla e gettare l'acqua. Questo passaggio serve a pulire il pollo e a garantire un brodo più limpido. In una pentola, unire l'alga kombu, il pollo sbollentato, l'acqua, il sakè, la salsa di soia, il mirin e lo zucchero. Portare a leggero bollore. Cuocere a fuoco basso per 25 minuti, schiumando di tanto in tanto le impurità che affiorano in superficie. A metà cottura, dopo circa 12 minuti, girare il pollo. Al termine della cottura, togliere il pollo e l'alga kombu dalla pentola. Lasciare raffreddare il pollo e il brodo separatamente, poi trasferire il brodo in frigorifero per farlo diventare ben freddo. Preparare i condimenti: tagliare il pollo cotto a fettine sottili e condirlo con un pizzico di sale. Tritare finemente il myoga e le foglie di shiso. Cuocere i somen seguendo le istruzioni sulla confezione. Scolarli e passarli immediatamente in una ciotola con acqua fredda e ghiaccio per bloccare la cottura e renderli più sodi. Scolarli di nuovo molto bene. Prendere il brodo freddo dal frigorifero, aggiungere l'aceto e mescolare. Mettere i somen in una ciotola, versarvi sopra il brodo freddo e guarnire con il trito di myoga e shiso, le fettine di pollo e i germogli di ravanello.",
+    "videoIds": []
   },
   "ricette/menrui/natto_soba": {
     "docId": "ricette/menrui/natto_soba",
@@ -293,7 +316,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Kizami nori",
       "1 uovo fresco che si possa mangiare crudo (opzionale)"
     ],
-    "instructionsText": "Bolli i soba in abbondante acqua (io non metto sale), sciacquali sotto l'acqua fredda, trasferiscili in una ciotola con acqua e ghiaccio per raffreddarli, scolali e asciugali bene, e mettili in una ciotola facendo una fossetta al centro, dove metterai il rosso dell'uovo. Aggiungi ai lati il natto, le cipolline tagliate sottili, il katsuobushi, il kizami nori, e il rosso dell'uovo al centro. Opzionale, come in foto, puoi aggiungere un paio di foglie di shiso fresco per guarnire. Mischia il mentsuyu e il dashi, per ottenere lo tsuyu, che verserai al lato della ciotola, per fare un fondo di circa 1 cm di altezza. E ora non ti resta che mangiare! Itadakimasu!"
+    "instructionsText": "Bolli i soba in abbondante acqua (io non metto sale), sciacquali sotto l'acqua fredda, trasferiscili in una ciotola con acqua e ghiaccio per raffreddarli, scolali e asciugali bene, e mettili in una ciotola facendo una fossetta al centro, dove metterai il rosso dell'uovo. Aggiungi ai lati il natto, le cipolline tagliate sottili, il katsuobushi, il kizami nori, e il rosso dell'uovo al centro. Opzionale, come in foto, puoi aggiungere un paio di foglie di shiso fresco per guarnire. Mischia il mentsuyu e il dashi, per ottenere lo tsuyu, che verserai al lato della ciotola, per fare un fondo di circa 1 cm di altezza. E ora non ti resta che mangiare! Itadakimasu!",
+    "videoIds": []
   },
   "ricette/menrui/tori_dashi_no_nyumen": {
     "docId": "ricette/menrui/tori_dashi_no_nyumen",
@@ -314,7 +338,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 porzioni di Somen",
       "Cipollotto (negi) per guarnire"
     ],
-    "instructionsText": "Il segreto di questo piatto risiede nella pulizia accurata della materia prima. Iniziamo mettendo le ossa di pollo, preferibilmente spezzate per rilasciare più sapore, in una pentola con un litro e mezzo d'acqua. Portiamo a bollore e lasciamo cuocere per pochi minuti finché non affiorano tutte le impurità in superficie; a questo punto gettiamo l'acqua e sciacquiamo bene le ossa sotto acqua corrente. Rimettiamo le ossa pulite nella pentola con il restante litro e mezzo d'acqua fresca, aggiungendo lo zenzero, lo scarto del porro, la salsa di soia, un pizzico di sale e lo zucchero. Copriamo e lasciamo sobbollire a fiamma bassa per circa un'ora, filtrando poi il brodo ottenuto con un colino a maglie fini per renderlo limpido. Mentre il brodo riposa, cuociamo i somen in acqua bollente per circa 3 minuti. Una volta pronti, è fondamentale scolarli e sciacquarli immediatamente sotto acqua corrente fredda, strofinandoli per rimuovere l'amido, e concludere con un breve bagno in acqua e ghiaccio per fermare la cottura. Per servire, disponiamo i somen in una ciotola, versiamo il brodo di pollo bollente e completiamo con il cipollotto tritato finemente."
+    "instructionsText": "Il segreto di questo piatto risiede nella pulizia accurata della materia prima. Iniziamo mettendo le ossa di pollo, preferibilmente spezzate per rilasciare più sapore, in una pentola con un litro e mezzo d'acqua. Portiamo a bollore e lasciamo cuocere per pochi minuti finché non affiorano tutte le impurità in superficie; a questo punto gettiamo l'acqua e sciacquiamo bene le ossa sotto acqua corrente. Rimettiamo le ossa pulite nella pentola con il restante litro e mezzo d'acqua fresca, aggiungendo lo zenzero, lo scarto del porro, la salsa di soia, un pizzico di sale e lo zucchero. Copriamo e lasciamo sobbollire a fiamma bassa per circa un'ora, filtrando poi il brodo ottenuto con un colino a maglie fini per renderlo limpido. Mentre il brodo riposa, cuociamo i somen in acqua bollente per circa 3 minuti. Una volta pronti, è fondamentale scolarli e sciacquarli immediatamente sotto acqua corrente fredda, strofinandoli per rimuovere l'amido, e concludere con un breve bagno in acqua e ghiaccio per fermare la cottura. Per servire, disponiamo i somen in una ciotola, versiamo il brodo di pollo bollente e completiamo con il cipollotto tritato finemente.",
+    "videoIds": [
+      "aQ8tXgcNsLM"
+    ]
   },
   "ricette/menrui/tororo_natto_shiso_udon": {
     "docId": "ricette/menrui/tororo_natto_shiso_udon",
@@ -339,7 +366,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Cipollotto (Negi)",
       "Salsa di soia (Shoyu) di ottima qualità"
     ],
-    "instructionsText": "Partiamo dal natto: è sempre un'ottima abitudine tenerne una scorta nel freezer. Quando lo prelevate, togliete la pellicola protettiva mentre è ancora congelato per evitare disastri appiccicosi, dopodiché scongelatelo rapidamente utilizzando il microonde. Una volta rinvenuto, conditelo con la sua salsina e la senape fornite nella confezione, e mescolatelo energicamente con le bacchette; più lo girate, più diventerà filante e \"sbavoso\", proprio come deve essere. Mentre l'acqua per la pasta arriva a bollore, occupiamoci del resto dei condimenti. Tritiamo finemente un po' di cipollotto verde e tagliamo a listarelle sottili le profumate foglie di shiso. A questo punto prendiamo il nostro yamaimo e lo sgrattugiamo vigorosamente fino a trasformarlo in tororo: una crema bianca, morbida, \"fluffosa\" e leggermente gelatinosa. Immergiamo gli udon nell'acqua bollente per un paio di minuti, giusto il tempo necessario affinché i noodles si separino e si ammorbidiscano. Li scoliamo e li laviamo accuratamente sotto l'acqua corrente, tuffandoli immediatamente in una ciotola di acqua e ghiaccio. Questo shock termico è vitale per fermare la cottura e ottenere una consistenza soda, elastica e perfettamente ghiacciata. Diamo un'ultima scolata rigorosa per non annacquare il piatto. È arrivato il momento dell'assemblaggio, la parte più divertente. In una bella ciotola capiente, posizioniamo gli udon ghiacciati sul fondo. Copriamo i noodles con una generosa cascata di tororo cremoso, adagiamo il natto filante al centro e circondiamo il tutto con lo shiso tritato. Facciamo cadere qualche goccia di salsa di soia di ottima qualità per dare la giusta sapidità, e concludiamo l'opera con il cipollotto."
+    "instructionsText": "Partiamo dal natto: è sempre un'ottima abitudine tenerne una scorta nel freezer. Quando lo prelevate, togliete la pellicola protettiva mentre è ancora congelato per evitare disastri appiccicosi, dopodiché scongelatelo rapidamente utilizzando il microonde. Una volta rinvenuto, conditelo con la sua salsina e la senape fornite nella confezione, e mescolatelo energicamente con le bacchette; più lo girate, più diventerà filante e \"sbavoso\", proprio come deve essere. Mentre l'acqua per la pasta arriva a bollore, occupiamoci del resto dei condimenti. Tritiamo finemente un po' di cipollotto verde e tagliamo a listarelle sottili le profumate foglie di shiso. A questo punto prendiamo il nostro yamaimo e lo sgrattugiamo vigorosamente fino a trasformarlo in tororo: una crema bianca, morbida, \"fluffosa\" e leggermente gelatinosa. Immergiamo gli udon nell'acqua bollente per un paio di minuti, giusto il tempo necessario affinché i noodles si separino e si ammorbidiscano. Li scoliamo e li laviamo accuratamente sotto l'acqua corrente, tuffandoli immediatamente in una ciotola di acqua e ghiaccio. Questo shock termico è vitale per fermare la cottura e ottenere una consistenza soda, elastica e perfettamente ghiacciata. Diamo un'ultima scolata rigorosa per non annacquare il piatto. È arrivato il momento dell'assemblaggio, la parte più divertente. In una bella ciotola capiente, posizioniamo gli udon ghiacciati sul fondo. Copriamo i noodles con una generosa cascata di tororo cremoso, adagiamo il natto filante al centro e circondiamo il tutto con lo shiso tritato. Facciamo cadere qualche goccia di salsa di soia di ottima qualità per dare la giusta sapidità, e concludiamo l'opera con il cipollotto.",
+    "videoIds": [
+      "fI0etHpnak8"
+    ]
   },
   "ricette/menrui/udon_burro_e_shoyu": {
     "docId": "ricette/menrui/udon_burro_e_shoyu",
@@ -361,7 +391,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Katsuobushi in abbondanza",
       "Kizami Nori (alga nori a striscioline) per guarnire"
     ],
-    "instructionsText": "Cuocere gli udon in abbondante acqua bollente per circa due minuti, o seguendo le istruzioni riportate sulla confezione. Scolare gli udon e trasferirli direttamente in una padella calda. Aggiungere subito la noce di burro e il cucchiaio di salsa di soia. Mantecare a fuoco vivo per circa un minuto, saltando gli udon come si farebbe con la pasta, finché il condimento non si sarà amalgamato creando una salsa cremosa. Impiattare immediatamente. Cospargere con abbondante katsuobushi (usandolo proprio come se fosse parmigiano) e guarnire con una manciata di kizami nori. È una soddisfazione unica, con un rapporto bontà-fatica imbattibile. Itadakimasu!"
+    "instructionsText": "Cuocere gli udon in abbondante acqua bollente per circa due minuti, o seguendo le istruzioni riportate sulla confezione. Scolare gli udon e trasferirli direttamente in una padella calda. Aggiungere subito la noce di burro e il cucchiaio di salsa di soia. Mantecare a fuoco vivo per circa un minuto, saltando gli udon come si farebbe con la pasta, finché il condimento non si sarà amalgamato creando una salsa cremosa. Impiattare immediatamente. Cospargere con abbondante katsuobushi (usandolo proprio come se fosse parmigiano) e guarnire con una manciata di kizami nori. È una soddisfazione unica, con un rapporto bontà-fatica imbattibile. Itadakimasu!",
+    "videoIds": []
   },
   "ricette/menrui/yaki_udon": {
     "docId": "ricette/menrui/yaki_udon",
@@ -389,7 +420,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Beni Shoga (zenzero rosso) per guarnire",
       "Olio di semi per la cottura"
     ],
-    "instructionsText": "Iniziamo la preparazione tagliando le verdure che formeranno la base del piatto. Tagliamo la carota a listarelle sottili e il cavolo cappuccio a pezzi grossolani. Un trucco importante riguarda la cipolla: va tagliata rigorosamente per il lungo; in questo modo manterrà la sua struttura e non si sfalderà durante la cottura. Tagliamo anche la fettina di carne di maiale a piccoli quadrotti. A parte, prepariamo una salsa mescolando in una ciotolina la salsa di soia, il mirin e il dashi in polvere. Questa e' una versione super semplificata della classica salsa per yakisoba, ma è perfetta per esaltare il sapore degli udon senza sovrastarli. Se volete fare la salda per yakisoba, trovate la ricetta completa qui. Scaldiamo bene una padella capiente (o un wok) con un cucchiaino di olio di semi e iniziamo rosolando i pezzetti di maiale. Una volta che la carne si e' dorata, inseriamo la cipolla, seguita dal cavolo cappuccio e dalle carote, saltando il tutto a fiamma vivace per farle ammorbidire ma preservandone la croccantezza. A questo punto, tuffiamo in padella i nostri udon e versiamo la salsa preparata precedentemente. Diamo una bella mescolata vigorosa saltando la pasta per distribuire i sapori in modo uniforme. Trasferiamo i nostri Yaki Udon ancora fumanti su un piatto da portata e arricchiamo il tutto con l'immancabile katsuobushi, che danzerà con il calore, e un tocco di beni shoga, lo zenzero rosso che aggiunge il perfetto contrasto acido. In soli 10 minuti e con pochissimi ingredienti, avrete portato in tavola l'autentico sapore del Giappone."
+    "instructionsText": "Iniziamo la preparazione tagliando le verdure che formeranno la base del piatto. Tagliamo la carota a listarelle sottili e il cavolo cappuccio a pezzi grossolani. Un trucco importante riguarda la cipolla: va tagliata rigorosamente per il lungo; in questo modo manterrà la sua struttura e non si sfalderà durante la cottura. Tagliamo anche la fettina di carne di maiale a piccoli quadrotti. A parte, prepariamo una salsa mescolando in una ciotolina la salsa di soia, il mirin e il dashi in polvere. Questa e' una versione super semplificata della classica salsa per yakisoba, ma è perfetta per esaltare il sapore degli udon senza sovrastarli. Se volete fare la salda per yakisoba, trovate la ricetta completa qui. Scaldiamo bene una padella capiente (o un wok) con un cucchiaino di olio di semi e iniziamo rosolando i pezzetti di maiale. Una volta che la carne si e' dorata, inseriamo la cipolla, seguita dal cavolo cappuccio e dalle carote, saltando il tutto a fiamma vivace per farle ammorbidire ma preservandone la croccantezza. A questo punto, tuffiamo in padella i nostri udon e versiamo la salsa preparata precedentemente. Diamo una bella mescolata vigorosa saltando la pasta per distribuire i sapori in modo uniforme. Trasferiamo i nostri Yaki Udon ancora fumanti su un piatto da portata e arricchiamo il tutto con l'immancabile katsuobushi, che danzerà con il calore, e un tocco di beni shoga, lo zenzero rosso che aggiunge il perfetto contrasto acido. In soli 10 minuti e con pochissimi ingredienti, avrete portato in tavola l'autentico sapore del Giappone.",
+    "videoIds": [
+      "7CIiq2RuUtc"
+    ]
   },
   "ricette/menrui/yakisoba": {
     "docId": "ricette/menrui/yakisoba",
@@ -414,7 +448,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Aonori",
       "Katsuobushi"
     ],
-    "instructionsText": "Preparare la pasta qualche ora prima, facendola super al dente (gli date giusto una sbollentata), scolate e sciaquatela bene sotto l'acqua fredda, scolatela di nuovo e conditela con un filo d'olio per evitare che si attacchi. Lasciatela a temperatura ambiente fino al momento di usarla. Potete metterla in un sacchetto di plastica ben chiuso, in modo che non si secchi, o in un contenitore ermetico. Taglia la cipolla a fette sottili, il cavolo cappuccio a quadratini, i funghi shiitake a fettine e la pancetta a striscioline. In una padella capiente o wok, scalda un po' d'olio e metti la panctta a rosolare. Quando inizia a rilasciare il grasso, aggiungi la cipolla, cuocendo fino a quando diventa trasparente. Aggiungi il cavolo cappuccio e i funghi shiitake, cuocendo fino a quando il cavolo inizia ad appassire. Aggiungi la pasta e mescola bene per amalgamare gli ingredienti. Versa la salsa yakisoba, dai una bella mescolata e cuoci per qualche minuto senza mescolare, in modo che la pasta faccia tutta una crosticina croccante. All'ultimo aggiungi il benishoga, mescola e servi con una spolverata di aonori e katsuobushi."
+    "instructionsText": "Preparare la pasta qualche ora prima, facendola super al dente (gli date giusto una sbollentata), scolate e sciaquatela bene sotto l'acqua fredda, scolatela di nuovo e conditela con un filo d'olio per evitare che si attacchi. Lasciatela a temperatura ambiente fino al momento di usarla. Potete metterla in un sacchetto di plastica ben chiuso, in modo che non si secchi, o in un contenitore ermetico. Taglia la cipolla a fette sottili, il cavolo cappuccio a quadratini, i funghi shiitake a fettine e la pancetta a striscioline. In una padella capiente o wok, scalda un po' d'olio e metti la panctta a rosolare. Quando inizia a rilasciare il grasso, aggiungi la cipolla, cuocendo fino a quando diventa trasparente. Aggiungi il cavolo cappuccio e i funghi shiitake, cuocendo fino a quando il cavolo inizia ad appassire. Aggiungi la pasta e mescola bene per amalgamare gli ingredienti. Versa la salsa yakisoba, dai una bella mescolata e cuoci per qualche minuto senza mescolare, in modo che la pasta faccia tutta una crosticina croccante. All'ultimo aggiungi il benishoga, mescola e servi con una spolverata di aonori e katsuobushi.",
+    "videoIds": []
   },
   "ricette/menrui/zaru_soba": {
     "docId": "ricette/menrui/zaru_soba",
@@ -431,7 +466,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeIngredient": [
       "200g di spaghetti di grano saraceno"
     ],
-    "instructionsText": "Bollire gli spaghetti in abbondante acqua senza sale per la durata suggerita sulla confezione. Scolarli conservando una tazza dell'acqua di cottura (sobayu). Usare un colino e sciacquarli sotto acqua corrente fredda con le mani per eliminare l'amido in eccesso. Trasferirli in una ciotola con acqua e ghiaccio per raffreddarli per circa 30 secondi, poi scolarli bene e metterli da parte."
+    "instructionsText": "Bollire gli spaghetti in abbondante acqua senza sale per la durata suggerita sulla confezione. Scolarli conservando una tazza dell'acqua di cottura (sobayu). Usare un colino e sciacquarli sotto acqua corrente fredda con le mani per eliminare l'amido in eccesso. Trasferirli in una ciotola con acqua e ghiaccio per raffreddarli per circa 30 secondi, poi scolarli bene e metterli da parte.",
+    "videoIds": []
   },
   "ricette/nimono/daikon_no_nimono": {
     "docId": "ricette/nimono/daikon_no_nimono",
@@ -449,7 +485,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     ],
     "recipeYield": null,
     "recipeIngredient": [],
-    "instructionsText": "Per iniziare, prendete un grosso daikon e privatelo delle estremità. Anche se la buccia può sembrare sottile, lo strato esterno è in realtà piuttosto coriaceo, quindi è fondamentale rimuoverlo interamente utilizzando la tecnica del katsuramuki, effettuando un taglio rotatorio con il coltello. Una volta pelato, tagliate il tubero in fette spesse circa 3-4 cm. Per evitare che le fette si sfaldino durante la lunga cottura, rifilate accuratamente gli spigoli di ogni disco seguendo la tecnica del mentori. Per favorire la penetrazione del calore e degli aromi, incidete una croce profonda un paio di centimetri su una delle basi di ogni fetta di daikon. Passate quindi alla fase di pre-cottura: mettete il daikon in una pentola e copritelo con l'acqua recuperata dal lavaggio del riso. Coprite con un otoshibuta e fate bollire per circa un'ora; l'amido contenuto nell'acqua del riso aiuterà a rimuovere l'amaro naturale della radice, rendendola dolcissima. Verificate la cottura con uno stuzzicandente: quando penetra la polpa senza resistenza, scolate il daikon e lavatelo delicatamente sotto acqua corrente. Rimettetelo sul fuoco coprendolo con acqua fresca, portate a bollore e sciacquatelo nuovamente. Questa doppia pulizia assicura un sapore pulito e delicato. Per la cottura finale, disponete le fette in una pentola e ricopritele interamente con del dashi. Aggiungete un cucchiaio di mirin e un paio di cucchiai di salsa di soia (shoyu). Posizionate nuovamente l'otoshibuta e lasciate sobbollire a fuoco dolce per circa mezz'ora. Al termine, spegnete la fiamma e lasciate riposare il daikon nel suo brodo fino a quando non si sarà raffreddato; questo passaggio è fondamentale affinché la radice assorba tutto l'umami del liquido. Mentre il daikon riposa, preparate il guarnimento affettando molto finemente della scorza di limone, avendo cura di prelevare solo la parte gialla. Potete servire il piatto sia freddo che caldo, accompagnandolo con il suo brodo di cottura e completando con le striscioline di limone. Se eseguito correttamente, il daikon risulterà così tenero da poter essere tagliato facilmente con le bacchette."
+    "instructionsText": "Per iniziare, prendete un grosso daikon e privatelo delle estremità. Anche se la buccia può sembrare sottile, lo strato esterno è in realtà piuttosto coriaceo, quindi è fondamentale rimuoverlo interamente utilizzando la tecnica del katsuramuki, effettuando un taglio rotatorio con il coltello. Una volta pelato, tagliate il tubero in fette spesse circa 3-4 cm. Per evitare che le fette si sfaldino durante la lunga cottura, rifilate accuratamente gli spigoli di ogni disco seguendo la tecnica del mentori. Per favorire la penetrazione del calore e degli aromi, incidete una croce profonda un paio di centimetri su una delle basi di ogni fetta di daikon. Passate quindi alla fase di pre-cottura: mettete il daikon in una pentola e copritelo con l'acqua recuperata dal lavaggio del riso. Coprite con un otoshibuta e fate bollire per circa un'ora; l'amido contenuto nell'acqua del riso aiuterà a rimuovere l'amaro naturale della radice, rendendola dolcissima. Verificate la cottura con uno stuzzicandente: quando penetra la polpa senza resistenza, scolate il daikon e lavatelo delicatamente sotto acqua corrente. Rimettetelo sul fuoco coprendolo con acqua fresca, portate a bollore e sciacquatelo nuovamente. Questa doppia pulizia assicura un sapore pulito e delicato. Per la cottura finale, disponete le fette in una pentola e ricopritele interamente con del dashi. Aggiungete un cucchiaio di mirin e un paio di cucchiai di salsa di soia (shoyu). Posizionate nuovamente l'otoshibuta e lasciate sobbollire a fuoco dolce per circa mezz'ora. Al termine, spegnete la fiamma e lasciate riposare il daikon nel suo brodo fino a quando non si sarà raffreddato; questo passaggio è fondamentale affinché la radice assorba tutto l'umami del liquido. Mentre il daikon riposa, preparate il guarnimento affettando molto finemente della scorza di limone, avendo cura di prelevare solo la parte gialla. Potete servire il piatto sia freddo che caldo, accompagnandolo con il suo brodo di cottura e completando con le striscioline di limone. Se eseguito correttamente, il daikon risulterà così tenero da poter essere tagliato facilmente con le bacchette.",
+    "videoIds": [
+      "W1llNvmnKHY"
+    ]
   },
   "ricette/nimono/kabocha_no_nimono": {
     "docId": "ricette/nimono/kabocha_no_nimono",
@@ -471,7 +510,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sake",
       "Zucchero (opzionale)"
     ],
-    "instructionsText": "Per questa ricetta l'ideale è utilizzare la zucca Mantovana, che è un sostituto perfetto per le zucche giapponesi, ed è facilmente reperibile. Iniziamo tagliando la zucca a pezzetti più o meno uguali, cercando di mantenere la buccia che in cottura diventerà tenera ed aiuterà i pezzi a non sfaldarsi. Prendiamo una pentola e disponiamo i pezzi di zucca sul fondo creando un vero e proprio mosaico, con la buccia preferibilmente rivolta verso l'alto o il basso in modo ordinato, cercando di non sovrapporli troppo. Copriamo il tutto con il dashi (usando il dashi vegano per mantenere la ricetta 100% vegetale) fino a coprire appena la zucca, e accendiamo il fuoco. Appena il liquido raggiunge il bollore, abbassiamo la fiamma al minimo e procediamo con il condimento. Aggiungiamo un paio di cucchiai di salsa di soia, un paio di mirin e un paio di sake, regolando le quantità in base a quanta zucca state cucinando. Se volete un sapore più dolce e glassato, potete aggiungere anche un cucchiaio di zucchero in questa fase. A questo punto copriamo con un otoshibuta, il tipico coperchio più piccolo della pentola che poggia direttamente sugli alimenti. Questo strumento è fondamentale nei nimono perché permette di usare meno brodo, diffonde il calore uniformemente e tiene fermi gli ingredienti evitando che si rompano col bollore. Se non lo avete, potete realizzarlo facilmente con un foglio di carta forno ritagliato a misura e bucato al centro. Lasciamo stufare per circa 10 minuti. Per verificare la cottura, facciamo la prova con uno stuzzicadenti: se entra facilmente nella polpa, la zucca è pronta."
+    "instructionsText": "Per questa ricetta l'ideale è utilizzare la zucca Mantovana, che è un sostituto perfetto per le zucche giapponesi, ed è facilmente reperibile. Iniziamo tagliando la zucca a pezzetti più o meno uguali, cercando di mantenere la buccia che in cottura diventerà tenera ed aiuterà i pezzi a non sfaldarsi. Prendiamo una pentola e disponiamo i pezzi di zucca sul fondo creando un vero e proprio mosaico, con la buccia preferibilmente rivolta verso l'alto o il basso in modo ordinato, cercando di non sovrapporli troppo. Copriamo il tutto con il dashi (usando il dashi vegano per mantenere la ricetta 100% vegetale) fino a coprire appena la zucca, e accendiamo il fuoco. Appena il liquido raggiunge il bollore, abbassiamo la fiamma al minimo e procediamo con il condimento. Aggiungiamo un paio di cucchiai di salsa di soia, un paio di mirin e un paio di sake, regolando le quantità in base a quanta zucca state cucinando. Se volete un sapore più dolce e glassato, potete aggiungere anche un cucchiaio di zucchero in questa fase. A questo punto copriamo con un otoshibuta, il tipico coperchio più piccolo della pentola che poggia direttamente sugli alimenti. Questo strumento è fondamentale nei nimono perché permette di usare meno brodo, diffonde il calore uniformemente e tiene fermi gli ingredienti evitando che si rompano col bollore. Se non lo avete, potete realizzarlo facilmente con un foglio di carta forno ritagliato a misura e bucato al centro. Lasciamo stufare per circa 10 minuti. Per verificare la cottura, facciamo la prova con uno stuzzicadenti: se entra facilmente nella polpa, la zucca è pronta.",
+    "videoIds": [
+      "usKM2qSpBQs"
+    ]
   },
   "ricette/nimono/kakuni": {
     "docId": "ricette/nimono/kakuni",
@@ -498,7 +540,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 pezzo di alga kombu",
       "4 uova"
     ],
-    "instructionsText": "Prima di tutto una premessa: questo è il metodo \"veloce\" per la preparazione del buta kaku-ni. Secondo il metodo tradizionale, spiegato ottimamente da Shizuo Tsuji nel suo libro \"Japanese Cooking: A Simple Art\" (praticamente la bibbia della cucina giapponese), ci vogliono due giorni per preparare il kakuni. Giuro che un giorno ci proverò, ma per ora mi accontento di questa versione. Tagliare la pancetta in pezzi di 5 cm di lato, e rosolare i cubi in una padella antiederente, 2 minuti per lato (12 minuti in totale). Asciugarli con un panno o dei fazzoletti di carta per eliminare il grasso in eccesso. Mettere i cubi di pancetta rosolata in una pentola a pressione, con il lato della pelle rivolto verso il basso. Aggiungere acqua tiepida ed un bicchiere di sake, fino a coprire la pancetta. Aggiungere la parte verde della cipolla e lo zenzero tagliato a fette. Chiudere la pentola a pressione e cuocere per mezz'ora. Scolare la pancetta e metterla da parte. Filtrare il brodo di cottura, facendolo freddare per poi togliere il grasso. Cuocere le uova in acqua bollente per 6 minuti e 30 secondi (prendendole dal frigo così partono sempre dalla stessa temperatura), in modo che restino liquide al centro, raffreddarle in acqua ghiacciata e sbucciarle. Sbollentare il bok choi in acqua bollente per 1 minuto, o saltarlo in padella con aglio e zenzero, e metterlo da parte. In una casseruola, mettere il brodo, la salsa di soia, il mirin, lo zucchero e il sake. Aggiungere la pancetta e il daikon tagliato a fette, e cuocere a fuoco basso facendo sobbollire per per 30 minuti. Negli ultimi 10 minuti aggiungere le uova e togliere il coperchio in modo che si ritiri un po' la salsa. Servire il kakuni con il bok choy e il daikon, e un po' di salsa. Guarnire a piacere con senape karashi, shichimi togarashi, e la parte bianca della cipolla verde tagliata a julienne e immersa in acqua fredda per arricciarla."
+    "instructionsText": "Prima di tutto una premessa: questo è il metodo \"veloce\" per la preparazione del buta kaku-ni. Secondo il metodo tradizionale, spiegato ottimamente da Shizuo Tsuji nel suo libro \"Japanese Cooking: A Simple Art\" (praticamente la bibbia della cucina giapponese), ci vogliono due giorni per preparare il kakuni. Giuro che un giorno ci proverò, ma per ora mi accontento di questa versione. Tagliare la pancetta in pezzi di 5 cm di lato, e rosolare i cubi in una padella antiederente, 2 minuti per lato (12 minuti in totale). Asciugarli con un panno o dei fazzoletti di carta per eliminare il grasso in eccesso. Mettere i cubi di pancetta rosolata in una pentola a pressione, con il lato della pelle rivolto verso il basso. Aggiungere acqua tiepida ed un bicchiere di sake, fino a coprire la pancetta. Aggiungere la parte verde della cipolla e lo zenzero tagliato a fette. Chiudere la pentola a pressione e cuocere per mezz'ora. Scolare la pancetta e metterla da parte. Filtrare il brodo di cottura, facendolo freddare per poi togliere il grasso. Cuocere le uova in acqua bollente per 6 minuti e 30 secondi (prendendole dal frigo così partono sempre dalla stessa temperatura), in modo che restino liquide al centro, raffreddarle in acqua ghiacciata e sbucciarle. Sbollentare il bok choi in acqua bollente per 1 minuto, o saltarlo in padella con aglio e zenzero, e metterlo da parte. In una casseruola, mettere il brodo, la salsa di soia, il mirin, lo zucchero e il sake. Aggiungere la pancetta e il daikon tagliato a fette, e cuocere a fuoco basso facendo sobbollire per per 30 minuti. Negli ultimi 10 minuti aggiungere le uova e togliere il coperchio in modo che si ritiri un po' la salsa. Servire il kakuni con il bok choy e il daikon, e un po' di salsa. Guarnire a piacere con senape karashi, shichimi togarashi, e la parte bianca della cipolla verde tagliata a julienne e immersa in acqua fredda per arricciarla.",
+    "videoIds": []
   },
   "ricette/nimono/nikujaga": {
     "docId": "ricette/nimono/nikujaga",
@@ -521,7 +564,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Salsa di soia (Shoyu) 3 cucchiai",
       "Taccole (opzionali, per guarnizione)"
     ],
-    "instructionsText": "La preparazione inizia con il taglio delle verdure, che in questo piatto deve essere piuttosto rustico ma curato. Tagliamo la carota e la cipolla a pezzettoni grossolani. La carne di manzo deve essere tagliata a straccetti o fettine sottili, ideali per una cottura in umido veloce che la mantenga morbida. Passiamo alle patate: dopo averle tagliate a pezzi grandi, è fondamentale eseguire il mentori. Con un pelapatate, rifiliamo tutti gli spigoli vivi di ogni pezzo di patata, smussandoli. Questa tecnica serve a evitare che la patata si sfaldi e si rompa durante la cottura nel liquido, mantenendo il brodo limpido e i pezzi integri. Per la cottura, l'ordine di inserimento degli ingredienti è importante. Scaldiamo un filo di olio di semi in una pentola capiente (o un tegame di ghisa) e inseriamo prima le patate, poi le cipolle. Rosoliamo le verdure insieme per qualche minuto per insaporirle. Solo a questo punto aggiungiamo la carne. Non cerchiamo una rosolatura aggressiva della carne, ma vogliamo cuocerla dolcemente affinché si sfaldi e diventi tenerissima in cottura. Una volta che la carne ha cambiato colore, uniamo le carote e copriamo tutto a filo con il dashi. Alziamo la fiamma al massimo e portiamo a bollore. Appena il liquido bolle, utilizziamo un colino a maglia fine per \"schiumare\" il brodo, rimuovendo tutte le impurità che affiorano in superficie. A questo punto condiamo aggiungendo un giro di mirin e di salsa di soia. Abbassiamo la fiamma al minimo e copriamo con un otoshibuta. Lasciamo cuocere dolcemente per circa 15 minuti. Trascorso questo tempo, spegniamo il fuoco e lasciamo riposare: è in questa fase che i sapori si amalgamano e le verdure assorbono il condimento. Mentre il Nikujaga riposa, possiamo sbollentare brevemente delle taccole in acqua salata: useremo il loro verde brillante come guarnizione decorativa per dare un tocco di colore al piatto finito."
+    "instructionsText": "La preparazione inizia con il taglio delle verdure, che in questo piatto deve essere piuttosto rustico ma curato. Tagliamo la carota e la cipolla a pezzettoni grossolani. La carne di manzo deve essere tagliata a straccetti o fettine sottili, ideali per una cottura in umido veloce che la mantenga morbida. Passiamo alle patate: dopo averle tagliate a pezzi grandi, è fondamentale eseguire il mentori. Con un pelapatate, rifiliamo tutti gli spigoli vivi di ogni pezzo di patata, smussandoli. Questa tecnica serve a evitare che la patata si sfaldi e si rompa durante la cottura nel liquido, mantenendo il brodo limpido e i pezzi integri. Per la cottura, l'ordine di inserimento degli ingredienti è importante. Scaldiamo un filo di olio di semi in una pentola capiente (o un tegame di ghisa) e inseriamo prima le patate, poi le cipolle. Rosoliamo le verdure insieme per qualche minuto per insaporirle. Solo a questo punto aggiungiamo la carne. Non cerchiamo una rosolatura aggressiva della carne, ma vogliamo cuocerla dolcemente affinché si sfaldi e diventi tenerissima in cottura. Una volta che la carne ha cambiato colore, uniamo le carote e copriamo tutto a filo con il dashi. Alziamo la fiamma al massimo e portiamo a bollore. Appena il liquido bolle, utilizziamo un colino a maglia fine per \"schiumare\" il brodo, rimuovendo tutte le impurità che affiorano in superficie. A questo punto condiamo aggiungendo un giro di mirin e di salsa di soia. Abbassiamo la fiamma al minimo e copriamo con un otoshibuta. Lasciamo cuocere dolcemente per circa 15 minuti. Trascorso questo tempo, spegniamo il fuoco e lasciamo riposare: è in questa fase che i sapori si amalgamano e le verdure assorbono il condimento. Mentre il Nikujaga riposa, possiamo sbollentare brevemente delle taccole in acqua salata: useremo il loro verde brillante come guarnizione decorativa per dare un tocco di colore al piatto finito.",
+    "videoIds": [
+      "yNDVtIMAxtY"
+    ]
   },
   "ricette/preparazioni_di_base/brodi/dashi": {
     "docId": "ricette/preparazioni_di_base/brodi/dashi",
@@ -539,7 +585,11 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "30 grammi di alga kombu",
       "35 grammi di katsuobushi"
     ],
-    "instructionsText": "Non togliere la polvere bianca dall'alga Kombu: quello è il glutammato naturalmente presente nell'alga, fonte di umami, ed è esattamente il motivo per cui usiamo la kombu. Versare l'acqua in una pentola, mettere l'alga kombu a bagno e lasciar riposare per almeno 1 ora (l'alga kombu deve reidratarsi completamente) Coprire con un coperchio e portare a 70 gradi a fiamma bassa (più ci mette, meglio è). Conviene usare un termometro, quando l’acqua raggiunge la temperatura spegnere la fiamma, e lasciare in infusione per altri 20 minuti. Togliere l’alga kombu, rialzare la fiamma e portare a 90 gradi, ed eliminare la schiuma con una schiumarola a setaccio fino. Spegnare la fiamma, e mettere il katsuobushi. Tenere il katsuobushi da 10-15 secondi per un dashi piu delicato, fino a 20-30 minuti per un dashi piu intenso. Togliere il katsuobushi e, e filtrare il brodo ottenuto con un panno fino. Complimenti avete appena fatto il dashi!"
+    "instructionsText": "Non togliere la polvere bianca dall'alga Kombu: quello è il glutammato naturalmente presente nell'alga, fonte di umami, ed è esattamente il motivo per cui usiamo la kombu. Versare l'acqua in una pentola, mettere l'alga kombu a bagno e lasciar riposare per almeno 1 ora (l'alga kombu deve reidratarsi completamente) Coprire con un coperchio e portare a 70 gradi a fiamma bassa (più ci mette, meglio è). Conviene usare un termometro, quando l’acqua raggiunge la temperatura spegnere la fiamma, e lasciare in infusione per altri 20 minuti. Togliere l’alga kombu, rialzare la fiamma e portare a 90 gradi, ed eliminare la schiuma con una schiumarola a setaccio fino. Spegnare la fiamma, e mettere il katsuobushi. Tenere il katsuobushi da 10-15 secondi per un dashi piu delicato, fino a 20-30 minuti per un dashi piu intenso. Togliere il katsuobushi e, e filtrare il brodo ottenuto con un panno fino. Complimenti avete appena fatto il dashi!",
+    "videoIds": [
+      "SQjoBpeNOhg",
+      "JzrHdn_lr-I"
+    ]
   },
   "ricette/preparazioni_di_base/brodi/mentsuyu": {
     "docId": "ricette/preparazioni_di_base/brodi/mentsuyu",
@@ -561,7 +611,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 pezzo di kombu (5 grammi? pesare)",
       "1 tazza di katsuobushi (pesare)"
     ],
-    "instructionsText": "Metti tutto in un pentolino e porta molto dolcemente a ebollizione, poi spegni il fuoco e lascia freddare Filtra tutto e metti in un barattolo, la salsa inizia a dare il meglio di se dopo 2-3 giorni in frigorifero. Non so ancora quanto si conservi a lungo, ne ho una di 2 mesi, sembra buona e non sono ancora morto."
+    "instructionsText": "Metti tutto in un pentolino e porta molto dolcemente a ebollizione, poi spegni il fuoco e lascia freddare Filtra tutto e metti in un barattolo, la salsa inizia a dare il meglio di se dopo 2-3 giorni in frigorifero. Non so ancora quanto si conservi a lungo, ne ho una di 2 mesi, sembra buona e non sono ancora morto.",
+    "videoIds": [
+      "gXeX1rC_YTs"
+    ]
   },
   "ricette/preparazioni_di_base/brodi/vegan_dashi": {
     "docId": "ricette/preparazioni_di_base/brodi/vegan_dashi",
@@ -581,7 +634,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "20-30g di Alga Kombu",
       "5 Funghi Shiitake disidratati (secchi)"
     ],
-    "instructionsText": "La preparazione richiede tempo e pazienza per estrarre al meglio i sapori in modo delicato (infusione a freddo)."
+    "instructionsText": "La preparazione richiede tempo e pazienza per estrarre al meglio i sapori in modo delicato (infusione a freddo).",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/condimenti/furikake": {
     "docId": "ricette/preparazioni_di_base/condimenti/furikake",
@@ -602,7 +656,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Semi di Sesamo",
       "Alga nori"
     ],
-    "instructionsText": "Se il Katsuobushi e' nuovo, prendetene una bella manciata e tostatelo in padella, come si fa col sesamo (ovvero a fuoco medio, senza coperchio, muovendolo spesso e togliendolo quando inizia a imbrunire) Se invece e' usato, strizzatelo benissimo, e cercate di sfilacciarlo il piu' possibile prima di metterlo in padella. Poi mettetelo in una padella bella ampia, in modo che non tenda ad appallottolarsi, e fare come sopra, ma con molto piu' tempo ed attenzione. Quando il Katsuobushi e' bello tostato, sbriciolatelo senza pieta' (si ma fate pezzetti, non sabbia...) L'alga kombu, se e' nuova ed essiccata, mettetela a bagno un po' per ammorbidirla, senno' finisce che ci rompete il coltello. E poi, nuova o usata che sia, fatela a quadratini di mezzo centimetro di lato. Tostate i semi di sesamo (come se fosse Katsuobushi), senza distrarvi e a fuoco medio-basso, perche' come vi distraete si carbonizzano immediatamente. Sbriciolate l'alga nori con le mani, da molta soddisfazione. Anche qui attenti a non fare l'Aonori per sbaglio. Comunque, siccome la kombu, cosi come e', e' dura da morire, mettetela in una padella, e metteteci tutto il condimento. Fate andare a fuoco basso, finche' il liquido non si sara' ritirato, e l'alga kombu ammorbidita. Se l'alga kombu e' ancora dura, aggiungete un po' di acqua e fate andare ancora. Quando il liquido avra' raggiunto la densita' della salsa Teriyaki quando e' pronta (ho imparato da mia madre a dare sempre istruzioni utilissime), spegnete il fuoco e aggiungete il katsuobushi, i semi di sesamo e l'alga nori, e mescolate bene. Alla fine vengono tutte palline ammappazzate ma non vi preccupate. Mettete tutto in forno su un bel foglio di carta da forno, a bassa temperatura (70-75 gradi), e ogni tanto aprite il forno, mescolate, sfragnate, e richiudete, finche' non sara' tutto bello secco e croccante. A questo punto dategli un'ultima sfragnata e mettete in un barattolo, e ciaone dal Giappone."
+    "instructionsText": "Se il Katsuobushi e' nuovo, prendetene una bella manciata e tostatelo in padella, come si fa col sesamo (ovvero a fuoco medio, senza coperchio, muovendolo spesso e togliendolo quando inizia a imbrunire) Se invece e' usato, strizzatelo benissimo, e cercate di sfilacciarlo il piu' possibile prima di metterlo in padella. Poi mettetelo in una padella bella ampia, in modo che non tenda ad appallottolarsi, e fare come sopra, ma con molto piu' tempo ed attenzione. Quando il Katsuobushi e' bello tostato, sbriciolatelo senza pieta' (si ma fate pezzetti, non sabbia...) L'alga kombu, se e' nuova ed essiccata, mettetela a bagno un po' per ammorbidirla, senno' finisce che ci rompete il coltello. E poi, nuova o usata che sia, fatela a quadratini di mezzo centimetro di lato. Tostate i semi di sesamo (come se fosse Katsuobushi), senza distrarvi e a fuoco medio-basso, perche' come vi distraete si carbonizzano immediatamente. Sbriciolate l'alga nori con le mani, da molta soddisfazione. Anche qui attenti a non fare l'Aonori per sbaglio. Comunque, siccome la kombu, cosi come e', e' dura da morire, mettetela in una padella, e metteteci tutto il condimento. Fate andare a fuoco basso, finche' il liquido non si sara' ritirato, e l'alga kombu ammorbidita. Se l'alga kombu e' ancora dura, aggiungete un po' di acqua e fate andare ancora. Quando il liquido avra' raggiunto la densita' della salsa Teriyaki quando e' pronta (ho imparato da mia madre a dare sempre istruzioni utilissime), spegnete il fuoco e aggiungete il katsuobushi, i semi di sesamo e l'alga nori, e mescolate bene. Alla fine vengono tutte palline ammappazzate ma non vi preccupate. Mettete tutto in forno su un bel foglio di carta da forno, a bassa temperatura (70-75 gradi), e ogni tanto aprite il forno, mescolate, sfragnate, e richiudete, finche' non sara' tutto bello secco e croccante. A questo punto dategli un'ultima sfragnata e mettete in un barattolo, e ciaone dal Giappone.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/nikiri": {
     "docId": "ricette/preparazioni_di_base/salse/nikiri",
@@ -621,7 +676,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1/2 tazza di sake",
       "1/2 tazza di dashi"
     ],
-    "instructionsText": "Metti il mirin e il sake in un pentolino a scaldare, e fai evaporare tutto l'alcol. Aggiungi la salsa di soia e il dashi, e fai sobbollire a fuoco basso fino a ridurre della metà il volume. Fai raffreddare e metti in frigo."
+    "instructionsText": "Metti il mirin e il sake in un pentolino a scaldare, e fai evaporare tutto l'alcol. Aggiungi la salsa di soia e il dashi, e fai sobbollire a fuoco basso fino a ridurre della metà il volume. Fai raffreddare e metti in frigo.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/okonomiyaki": {
     "docId": "ricette/preparazioni_di_base/salse/okonomiyaki",
@@ -641,7 +697,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di salsa di soia (shoyu), meglio se koikuchi (scura e saporita)",
       "1 cucchiaino di aceto di mele o aceto di riso (opzionale, se preferisci un tocco acidulo)"
     ],
-    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di ostriche. Aiutati con una piccola frusta per amalgamare bene il composto. Aggiungi lo zucchero (o il miele) e gira finché si scioglie del tutto, dando alla salsa la dolcezza tipica per l’okonomiyaki. Versa la salsa di soia e, se desideri una punta di acidità in più, un cucchiaino di aceto (di mele o di riso). Continua a mescolare finché il tutto non risulta ben omogeneo. Prova la salsa e, se occorre, aggiungi un pizzico di zucchero o qualche goccia di soia in più, per bilanciare dolce, salato e acidulo secondo il tuo gusto."
+    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di ostriche. Aiutati con una piccola frusta per amalgamare bene il composto. Aggiungi lo zucchero (o il miele) e gira finché si scioglie del tutto, dando alla salsa la dolcezza tipica per l’okonomiyaki. Versa la salsa di soia e, se desideri una punta di acidità in più, un cucchiaino di aceto (di mele o di riso). Continua a mescolare finché il tutto non risulta ben omogeneo. Prova la salsa e, se occorre, aggiungi un pizzico di zucchero o qualche goccia di soia in più, per bilanciare dolce, salato e acidulo secondo il tuo gusto.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/ponzu": {
     "docId": "ricette/preparazioni_di_base/salse/ponzu",
@@ -662,7 +719,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "½ parte di aceto di riso",
       "1 parte di mirin"
     ],
-    "instructionsText": "Mescolare a freddo in una ciotolina, e lasciare riposare in frigo per almeno 30 minuti prima di servire. Si conserva per un sacco di tempo, non sono mai riuscito a farla andare a male!"
+    "instructionsText": "Mescolare a freddo in una ciotolina, e lasciare riposare in frigo per almeno 30 minuti prima di servire. Si conserva per un sacco di tempo, non sono mai riuscito a farla andare a male!",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/takoyaki": {
     "docId": "ricette/preparazioni_di_base/salse/takoyaki",
@@ -678,7 +736,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "¾ cucchiaio di zucchero",
       "½ cucchiaio di ketchup"
     ],
-    "instructionsText": "Mescolare a freddo - e regolare lo zucchero in base alla dolcezza del ketchup"
+    "instructionsText": "Mescolare a freddo - e regolare lo zucchero in base alla dolcezza del ketchup",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/tentsuyu": {
     "docId": "ricette/preparazioni_di_base/salse/tentsuyu",
@@ -697,7 +756,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 parte salsa di soia",
       "Daikon grattugiato"
     ],
-    "instructionsText": "Versare tutti gli ingredienti in un pentolino, e scaldare fino a sobbollire (se c'e' lo zucchero, controllare che sia completamente dissolto), far freddare e conservare in un barattolo in frigorifero (2-3 settimane max) Quando si serve, mischiare con daikon grattugiato"
+    "instructionsText": "Versare tutti gli ingredienti in un pentolino, e scaldare fino a sobbollire (se c'e' lo zucchero, controllare che sia completamente dissolto), far freddare e conservare in un barattolo in frigorifero (2-3 settimane max) Quando si serve, mischiare con daikon grattugiato",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/teriyaki": {
     "docId": "ricette/preparazioni_di_base/salse/teriyaki",
@@ -718,7 +778,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "½ parte di zucchero (opzionale, o anche meno)",
       "fecola di patate o amido di mais (maizena) q.b."
     ],
-    "instructionsText": "In un piccolo tegame, riscaldare il sake e il mirin fino al lieve bollore. Utilizzando un accendino con punta lunga, incendiare l'alcool in eccesso. Successivamente, incorporare la salsa di soia e lo zucchero, mescolando a fuoco bassissimo fino a ottenere un leggero sobbollimento. Questo processo conferisce alla salsa di soia una nota più profonda e favorisce una leggera caramellizzazione. È possibile arricchire il sapore aggiungendo la parte verde dei porri, fettine di zenzero o aglio tritato, a seconda delle preferenze o del piatto a cui è destinata. Io continuo la cottura fino a che non si riduce di circa la metà del suo volume, ma potete proseguire fino a raggiungere l'intensità di sapore desiderata. A parte, diluire la fecola di patate in un po' d'acqua fredda, poi versarla nel tegame, mescolando accuratamente, e lasciar sobbollire per altri 5 minuti. La salsa si addensa e diventa liscia e lucida."
+    "instructionsText": "In un piccolo tegame, riscaldare il sake e il mirin fino al lieve bollore. Utilizzando un accendino con punta lunga, incendiare l'alcool in eccesso. Successivamente, incorporare la salsa di soia e lo zucchero, mescolando a fuoco bassissimo fino a ottenere un leggero sobbollimento. Questo processo conferisce alla salsa di soia una nota più profonda e favorisce una leggera caramellizzazione. È possibile arricchire il sapore aggiungendo la parte verde dei porri, fettine di zenzero o aglio tritato, a seconda delle preferenze o del piatto a cui è destinata. Io continuo la cottura fino a che non si riduce di circa la metà del suo volume, ma potete proseguire fino a raggiungere l'intensità di sapore desiderata. A parte, diluire la fecola di patate in un po' d'acqua fredda, poi versarla nel tegame, mescolando accuratamente, e lasciar sobbollire per altri 5 minuti. La salsa si addensa e diventa liscia e lucida.",
+    "videoIds": [
+      "zQowDw_-cOo"
+    ]
   },
   "ricette/preparazioni_di_base/salse/tonkatsu": {
     "docId": "ricette/preparazioni_di_base/salse/tonkatsu",
@@ -736,7 +799,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di senape giapponese (karashi) o, in mancanza, di senape delicata/dijon",
       "1 cucchiaio di aceto di mele (opzionale, se desideri una nota più acidula)"
     ],
-    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di soia. Aggiungi lo zucchero (o il mirin) e mescola con una piccola frusta o un cucchiaio fino a farlo sciogliere completamente. Se preferisci un tocco più delicato, usa il mirin al posto dello zucchero. Incorpora il cucchiaino di senape (karashi o dijon) e, se gradisci una punta di acidità in più, un cucchiaio di aceto di mele. Continua a mescolare finché il composto non risulta omogeneo. Prova la salsa e, se necessario, modifica il bilanciamento dolce-salato-agro, regolando con un pizzico di zucchero o qualche goccia in più di salsa di soia."
+    "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di soia. Aggiungi lo zucchero (o il mirin) e mescola con una piccola frusta o un cucchiaio fino a farlo sciogliere completamente. Se preferisci un tocco più delicato, usa il mirin al posto dello zucchero. Incorpora il cucchiaino di senape (karashi o dijon) e, se gradisci una punta di acidità in più, un cucchiaio di aceto di mele. Continua a mescolare finché il composto non risulta omogeneo. Prova la salsa e, se necessario, modifica il bilanciamento dolce-salato-agro, regolando con un pizzico di zucchero o qualche goccia in più di salsa di soia.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/yakisoba_sauce": {
     "docId": "ricette/preparazioni_di_base/salse/yakisoba_sauce",
@@ -753,7 +817,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio e mezzo di Salsa di soia",
       "4 cucchiai di Salsa worcestershire"
     ],
-    "instructionsText": "In una ciotola, versare per primo lo zucchero. Questo è il passaggio più importante per assicurarsi che si sciolga bene. Aggiungere le salse procedendo dalla più densa alla più liquida per facilitare la miscelazione. Iniziare quindi con il ketchup, seguito dalla salsa di ostriche. Versare infine la salsa di soia e la salsa worcestershire. Mescolare energicamente con un cucchiaio o una piccola frusta finché lo zucchero non sarà completamente disciolto e la salsa non risulterà omogenea. La salsa è pronta per essere usata, ma il giorno dopo sarà ancora meglio, quando i sapori si saranno amalgamati. Si conserva in frigorifero per una settimana circa."
+    "instructionsText": "In una ciotola, versare per primo lo zucchero. Questo è il passaggio più importante per assicurarsi che si sciolga bene. Aggiungere le salse procedendo dalla più densa alla più liquida per facilitare la miscelazione. Iniziare quindi con il ketchup, seguito dalla salsa di ostriche. Versare infine la salsa di soia e la salsa worcestershire. Mescolare energicamente con un cucchiaio o una piccola frusta finché lo zucchero non sarà completamente disciolto e la salsa non risulterà omogenea. La salsa è pronta per essere usata, ma il giorno dopo sarà ancora meglio, quando i sapori si saranno amalgamati. Si conserva in frigorifero per una settimana circa.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/salse/yakitori": {
     "docId": "ricette/preparazioni_di_base/salse/yakitori",
@@ -775,7 +840,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Parte verde delle cipolline o porro",
       "Opzionale - zenzero e aglio grattugiati"
     ],
-    "instructionsText": "Bollire al minimo fino a ridurre della metà il volume."
+    "instructionsText": "Bollire al minimo fino a ridurre della metà il volume.",
+    "videoIds": []
   },
   "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar": {
     "docId": "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar",
@@ -786,7 +852,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeKeywords": [],
     "recipeYield": null,
     "recipeIngredient": [],
-    "instructionsText": "Sciogliere completamente lo zucchero e il sale nell'aceto, aggiungere l'alga e lasciare riposare per 24 ore in frigorifero. Dopo 24 ore, filtrare e imbottigliare, ed e' pronto per l'uso."
+    "instructionsText": "Sciogliere completamente lo zucchero e il sale nell'aceto, aggiungere l'alga e lasciare riposare per 24 ore in frigorifero. Dopo 24 ore, filtrare e imbottigliare, ed e' pronto per l'uso.",
+    "videoIds": []
   },
   "ricette/riso/gyudon": {
     "docId": "ricette/riso/gyudon",
@@ -812,7 +879,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiai di mirin",
       "2 cucchiai di sake"
     ],
-    "instructionsText": "Taglia la cipolla a fettine sottili per il lungo, e la cipollina verde a rondelle sottili. In una padella mmetti il dashi, la salsa di soia, il mirin e il sake e le cipolle, fai cuocere a fuoco medio fino a che le cipolle non si ammorbidiscono. Usa un coperchio per non far evaporare il brodo. Dopo 2-3 minuti aggiungi la carne e fai cuocere finche' la carne non e' piu' rosa. Quando la carne e' cotta, spegni il fuoco e aggiungi la cipollina verde. Versa il tutto sopra il riso caldo e guarnisci con beni shoga."
+    "instructionsText": "Taglia la cipolla a fettine sottili per il lungo, e la cipollina verde a rondelle sottili. In una padella mmetti il dashi, la salsa di soia, il mirin e il sake e le cipolle, fai cuocere a fuoco medio fino a che le cipolle non si ammorbidiscono. Usa un coperchio per non far evaporare il brodo. Dopo 2-3 minuti aggiungi la carne e fai cuocere finche' la carne non e' piu' rosa. Quando la carne e' cotta, spegni il fuoco e aggiungi la cipollina verde. Versa il tutto sopra il riso caldo e guarnisci con beni shoga.",
+    "videoIds": [
+      "KYZHouOLnr4"
+    ]
   },
   "ricette/riso/hamburger_don": {
     "docId": "ricette/riso/hamburger_don",
@@ -832,7 +902,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale e pepe q.b.",
       "1 cucchiaio di Olio di semi"
     ],
-    "instructionsText": "Tritare finemente la cipolla. Scaldare l'olio di semi in una padella a fuoco medio. Aggiungere la cipolla e soffriggere finché non appassisce. Aggiungere la carne macinata mista, condire con sale e pepe. Continuare a cuocere, premendo la carne per rosolarla e sgranarla, finché non è ben cotta. Aggiungere il ketchup e la salsa Worcestershire e saltare per 1-2 minuti finché il liquido in eccesso non evapora. Creare tre incavi nel composto di carne. Rompere un uovo in ciascun incavo. Abbassare la fiamma e cuocere per circa 5 minuti, o finché le uova non raggiungono la cottura desiderata. Mettere il riso caldo nelle ciotole individuali e adagiarvi sopra il composto di carne e uova."
+    "instructionsText": "Tritare finemente la cipolla. Scaldare l'olio di semi in una padella a fuoco medio. Aggiungere la cipolla e soffriggere finché non appassisce. Aggiungere la carne macinata mista, condire con sale e pepe. Continuare a cuocere, premendo la carne per rosolarla e sgranarla, finché non è ben cotta. Aggiungere il ketchup e la salsa Worcestershire e saltare per 1-2 minuti finché il liquido in eccesso non evapora. Creare tre incavi nel composto di carne. Rompere un uovo in ciascun incavo. Abbassare la fiamma e cuocere per circa 5 minuti, o finché le uova non raggiungono la cottura desiderata. Mettere il riso caldo nelle ciotole individuali e adagiarvi sopra il composto di carne e uova.",
+    "videoIds": [
+      "SJweMEALMks"
+    ]
   },
   "ricette/riso/nira_shio_kombu_onigiri": {
     "docId": "ricette/riso/nira_shio_kombu_onigiri",
@@ -859,7 +932,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Alga Nori",
       "Sale q.b."
     ],
-    "instructionsText": "Iniziamo tritando finemente l'erba aglina (nira) al coltello. In una ciotola capiente, disponiamo il riso cotto, che per questa preparazione deve essere rigorosamente ben caldo. Aggiungiamo in grande abbondanza la nira, il sesamo, un bel giro di olio di sesamo, lo shio kombu e il katsuobushi. Con l'aiuto di una spatola, mischiamo bene tutto il composto. Passiamo ora alla formatura delle nostre magiche polpette di riso giapponesi. È fondamentale avere le mani bagnate e ben salate per evitare che il riso si attacchi e per dare sapidità all'esterno. L'arte dell'onigiri sta nell'appallottolare e \"striangolare\" il composto con delicatezza: non dobbiamo fare una palla appiccicosa, ma dobbiamo assicurarci di mantenerlo arioso e \"fluffoso\" all'interno. Per aiutare gli onigiri a mantenere perfettamente la forma, è consentito e suggerito avvilupparli strettamente nella pellicola da cucina. Li lasciamo riposare così finché non si potranno raffreddare e solidificare a dovere. Il tocco finale è l'alga. Prendiamo un foglio di alga nori e, prestando attenzione, lo passiamo direttamente sopra la fiamma viva del fornello per averla bella croccante. Liberiamo gli onigiri dalla pellicola, li avvolgiamo nella nori appena tostata e la magia è servita."
+    "instructionsText": "Iniziamo tritando finemente l'erba aglina (nira) al coltello. In una ciotola capiente, disponiamo il riso cotto, che per questa preparazione deve essere rigorosamente ben caldo. Aggiungiamo in grande abbondanza la nira, il sesamo, un bel giro di olio di sesamo, lo shio kombu e il katsuobushi. Con l'aiuto di una spatola, mischiamo bene tutto il composto. Passiamo ora alla formatura delle nostre magiche polpette di riso giapponesi. È fondamentale avere le mani bagnate e ben salate per evitare che il riso si attacchi e per dare sapidità all'esterno. L'arte dell'onigiri sta nell'appallottolare e \"striangolare\" il composto con delicatezza: non dobbiamo fare una palla appiccicosa, ma dobbiamo assicurarci di mantenerlo arioso e \"fluffoso\" all'interno. Per aiutare gli onigiri a mantenere perfettamente la forma, è consentito e suggerito avvilupparli strettamente nella pellicola da cucina. Li lasciamo riposare così finché non si potranno raffreddare e solidificare a dovere. Il tocco finale è l'alga. Prendiamo un foglio di alga nori e, prestando attenzione, lo passiamo direttamente sopra la fiamma viva del fornello per averla bella croccante. Liberiamo gli onigiri dalla pellicola, li avvolgiamo nella nori appena tostata e la magia è servita.",
+    "videoIds": [
+      "wEFtXLWRuTQ"
+    ]
   },
   "ricette/riso/onigiri": {
     "docId": "ricette/riso/onigiri",
@@ -880,7 +956,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale fino",
       "2 Fogli di Alga Nori"
     ],
-    "instructionsText": "Sciacqua il riso sotto acqua fredda fino a che l'acqua non risulta limpida. Cuoci il riso con la quantità di acqua indicata, utilizzando una pentola con coperchio o una cuociriso. Una volta cotto, lascia riposare coperto per 10 minuti. Mentre il riso cuoce, prepariamo il ripieno. Scola il tonno molto accuratamente. In una ciotola, mescola il tonno con la maionese fino a ottenere un composto omogeneo e cremoso, ma non eccessivamente liquido. Puoi aggiungere un pizzico di pepe nero o meglio ancora di shichimi togarashi). Tieni una piccola ciotola d'acqua con un pizzico di sale. Bagna le mani con l'acqua salata: questo aiuterà a non far attaccare il riso e a condire l'esterno dell'onigiri. Prendi una porzione di riso cotto, grande piu o meno come una palla da tennis, e appiattiscila nel palmo della mano, creando una conca al centro. Metti un cucchiaio abbondante di ripieno di tonno e maionese nella conca. Copri il ripieno con il riso circostante e sigillalo completamente, poi modella il tutto con entrambe le mani nella classica forma triangolare, premendo delicatamente per compattare. Taglia i fogli di alga nori a strisce (circa 3-4 cm di larghezza). Avvolgi una striscia alla base dell'onigiri, lasciando le estremità rivolte verso l'esterno, per creare un pratico punto in cui afferrare lo snack senza toccare il riso."
+    "instructionsText": "Sciacqua il riso sotto acqua fredda fino a che l'acqua non risulta limpida. Cuoci il riso con la quantità di acqua indicata, utilizzando una pentola con coperchio o una cuociriso. Una volta cotto, lascia riposare coperto per 10 minuti. Mentre il riso cuoce, prepariamo il ripieno. Scola il tonno molto accuratamente. In una ciotola, mescola il tonno con la maionese fino a ottenere un composto omogeneo e cremoso, ma non eccessivamente liquido. Puoi aggiungere un pizzico di pepe nero o meglio ancora di shichimi togarashi). Tieni una piccola ciotola d'acqua con un pizzico di sale. Bagna le mani con l'acqua salata: questo aiuterà a non far attaccare il riso e a condire l'esterno dell'onigiri. Prendi una porzione di riso cotto, grande piu o meno come una palla da tennis, e appiattiscila nel palmo della mano, creando una conca al centro. Metti un cucchiaio abbondante di ripieno di tonno e maionese nella conca. Copri il ripieno con il riso circostante e sigillalo completamente, poi modella il tutto con entrambe le mani nella classica forma triangolare, premendo delicatamente per compattare. Taglia i fogli di alga nori a strisce (circa 3-4 cm di larghezza). Avvolgi una striscia alla base dell'onigiri, lasciando le estremità rivolte verso l'esterno, per creare un pratico punto in cui afferrare lo snack senza toccare il riso.",
+    "videoIds": [
+      "okzY1FVMwDg"
+    ]
   },
   "ricette/riso/onigiri_kimchi_asiago": {
     "docId": "ricette/riso/onigiri_kimchi_asiago",
@@ -900,7 +979,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Alga Nori",
       "Olio di semi q.b."
     ],
-    "instructionsText": "Iniziamo la preparazione tritando finemente al coltello il kimchi e grattugiando il formaggio Asiago. In una ciotola capiente, uniamo questi due ingredienti al riso. È fondamentale che il riso sia ancora ben caldo, mi raccomando bello fumante, affinché i sapori si amalgamino perfettamente e il formaggio inizi a sciogliersi. Mescoliamo il composto con gran delicatezza: non vogliamo fare un pappone. Passiamo ora alla formatura. Ci bagniamo ben bene le mani con l'acqua per impedire al riso di appiccicarsi e iniziamo a striangolare il composto, compattandolo fino a dargli la classica forma a triangolo. Non preoccupatevi se all'inizio non vengono dei bellissimi onigiri. Un trucco professionale per assicurarci che tengano bene la forma è avvolgere ogni onigiri con della pellicola da cucina e farli riposare per una mezz'oretta, affinché si compattino bene. Trascorso il tempo di riposo, ungiamo una padella con un po' di olio di semi e la scaldiamo a fuoco basso. Adagiamo delicatamente i nostri onigiri e li facciamo croccare a fiamma bassa da tutti i lati, ma proprio tutti. Per completare, come dei veri professionisti, facciamo croccare la nostra alga nori passandola rapidamente a fiamma viva sul fornello. Capirete che è bella secca quando si spezzerà da sola. Aggiungiamo l'alga all'ultimo momento, a mo' di tovagliolino edibile, in maniera che rimanga bella croccante mentre addentiamo il nostro onigiri filante e saporito."
+    "instructionsText": "Iniziamo la preparazione tritando finemente al coltello il kimchi e grattugiando il formaggio Asiago. In una ciotola capiente, uniamo questi due ingredienti al riso. È fondamentale che il riso sia ancora ben caldo, mi raccomando bello fumante, affinché i sapori si amalgamino perfettamente e il formaggio inizi a sciogliersi. Mescoliamo il composto con gran delicatezza: non vogliamo fare un pappone. Passiamo ora alla formatura. Ci bagniamo ben bene le mani con l'acqua per impedire al riso di appiccicarsi e iniziamo a striangolare il composto, compattandolo fino a dargli la classica forma a triangolo. Non preoccupatevi se all'inizio non vengono dei bellissimi onigiri. Un trucco professionale per assicurarci che tengano bene la forma è avvolgere ogni onigiri con della pellicola da cucina e farli riposare per una mezz'oretta, affinché si compattino bene. Trascorso il tempo di riposo, ungiamo una padella con un po' di olio di semi e la scaldiamo a fuoco basso. Adagiamo delicatamente i nostri onigiri e li facciamo croccare a fiamma bassa da tutti i lati, ma proprio tutti. Per completare, come dei veri professionisti, facciamo croccare la nostra alga nori passandola rapidamente a fiamma viva sul fornello. Capirete che è bella secca quando si spezzerà da sola. Aggiungiamo l'alga all'ultimo momento, a mo' di tovagliolino edibile, in maniera che rimanga bella croccante mentre addentiamo il nostro onigiri filante e saporito.",
+    "videoIds": [
+      "KNOLKWzaFMs"
+    ]
   },
   "ricette/riso/oyakodon": {
     "docId": "ricette/riso/oyakodon",
@@ -927,7 +1009,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiai di sake",
       "olio di semi di arachide"
     ],
-    "instructionsText": "L'Oyakodon va fatto su una padellina monoporzione, perche' poi lo fai scivolare tutto direttamente sulla ciotola di riso (caldo) Taglia la cipolla a fettine secondo la lunghezza della cipolla, il pollo a cubetti, e le cipolline a rondelle o losanghe. Rompi le uova in una ciotolina, e mescolale delicatamente (senza sbatterle) con le bacchette. Marina il pollo nel sake per 20 minuti. Asciuga bene il pollo e fallo rosolare a fuoco basso girandolo una sola volta quando si e' dorato. Quando e' dorato da entrambi i lati, toglierlo dalla padellina e metterlo da parte. Versa il dashi, il mirin e la salsa di soia nel pentolino, accendi il fuoco, aggiungi le cipolle e fai sobollire a fuoco medio-basso per 4 minuti. A questo punto abbassa la fiamma, e aggiungi il pollo. Fai sobollire per altri 2 minuti, fin quando il pollo non e' completamente cotto e il brodo non si e' ristretto un po'. Alza il fuoco a medio, versa delicatamente 2/3 dell'uovo cercando di coprire tutto. Mischia il resto dell'uovo alle cipolline e mettilo da parte. Fai andare 30-40 secondi a fuoco medio, poi abbassa la fiamma e cuoci un altro minuto, il brodo non si deve essere asciugato. Mischia molto delicatamente, e versa il restante uovo con le cipolline. A questo punto, spegni pure la fiamma e fai cuocere con il calore residuo per un altro minuto. La ricetta originale (come piace a me) prevede che l'uovo resti mezzo crudo e bello bavoso. Trasferisci il contenuto del pentolino direttamente sul riso facendocelo scivolare sopra. Servire caldo."
+    "instructionsText": "L'Oyakodon va fatto su una padellina monoporzione, perche' poi lo fai scivolare tutto direttamente sulla ciotola di riso (caldo) Taglia la cipolla a fettine secondo la lunghezza della cipolla, il pollo a cubetti, e le cipolline a rondelle o losanghe. Rompi le uova in una ciotolina, e mescolale delicatamente (senza sbatterle) con le bacchette. Marina il pollo nel sake per 20 minuti. Asciuga bene il pollo e fallo rosolare a fuoco basso girandolo una sola volta quando si e' dorato. Quando e' dorato da entrambi i lati, toglierlo dalla padellina e metterlo da parte. Versa il dashi, il mirin e la salsa di soia nel pentolino, accendi il fuoco, aggiungi le cipolle e fai sobollire a fuoco medio-basso per 4 minuti. A questo punto abbassa la fiamma, e aggiungi il pollo. Fai sobollire per altri 2 minuti, fin quando il pollo non e' completamente cotto e il brodo non si e' ristretto un po'. Alza il fuoco a medio, versa delicatamente 2/3 dell'uovo cercando di coprire tutto. Mischia il resto dell'uovo alle cipolline e mettilo da parte. Fai andare 30-40 secondi a fuoco medio, poi abbassa la fiamma e cuoci un altro minuto, il brodo non si deve essere asciugato. Mischia molto delicatamente, e versa il restante uovo con le cipolline. A questo punto, spegni pure la fiamma e fai cuocere con il calore residuo per un altro minuto. La ricetta originale (come piace a me) prevede che l'uovo resti mezzo crudo e bello bavoso. Trasferisci il contenuto del pentolino direttamente sul riso facendocelo scivolare sopra. Servire caldo.",
+    "videoIds": []
   },
   "ricette/riso/soborodon": {
     "docId": "ricette/riso/soborodon",
@@ -957,7 +1040,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Beni Shoga (zenzero rosso marinato) q.b.",
       "Olio di semi q.b."
     ],
-    "instructionsText": "Iniziamo occupandoci delle uova, che andranno a formare la prima metà del nostro colorato mosaico. Rompiamo le uova in una ciotola, sbattiamole leggermente con le bacchette e versiamole in una padella scaldata con un filo d'olio. Dobbiamo strapazzarle in modo continuo e veloce, cercando di creare dei grumi piccoli e soffici, senza seccarle troppo. Una volta pronte, trasferiamole su un piatto e teniamole da parte. Nella stessa padella (non serve lavarla), inseriamo la carne macinata di pollo cruda. Aggiungiamo subito i condimenti: il mirin, il sake, la salsa di soia e lo zenzero fresco grattugiato. Accendiamo il fuoco e iniziamo a cuocere sgranando la carne in continuazione con una spatola di legno. Questo passaggio è fondamentale: la carne deve cuocersi sminuzzandosi il più possibile, assorbendo tutti i liquidi della marinatura. Continuiamo la cottura fino a quando il sughetto sul fondo non si sarà quasi completamente asciugato, lasciando il macinato saporito e ben sgranato. Ora arriva il momento più divertente: l'assemblaggio. Prepariamo una ciotola capiente creando una base soffice di riso bianco. Disponiamo le uova strapazzate su una metà della ciotola e il macinato di pollo sull'altra metà. Per separare queste due \"tifoserie\", creiamo una coreografica linea di demarcazione centrale utilizzando i piselli sbollentati. Infine, per dare un tocco di acidità che pulisce il palato e un accento di colore rosso vivo, adagiamo al centro un ciuffetto di beni shoga. Il vostro Soboro Don è pronto per essere ammirato e, soprattutto, divorato!"
+    "instructionsText": "Iniziamo occupandoci delle uova, che andranno a formare la prima metà del nostro colorato mosaico. Rompiamo le uova in una ciotola, sbattiamole leggermente con le bacchette e versiamole in una padella scaldata con un filo d'olio. Dobbiamo strapazzarle in modo continuo e veloce, cercando di creare dei grumi piccoli e soffici, senza seccarle troppo. Una volta pronte, trasferiamole su un piatto e teniamole da parte. Nella stessa padella (non serve lavarla), inseriamo la carne macinata di pollo cruda. Aggiungiamo subito i condimenti: il mirin, il sake, la salsa di soia e lo zenzero fresco grattugiato. Accendiamo il fuoco e iniziamo a cuocere sgranando la carne in continuazione con una spatola di legno. Questo passaggio è fondamentale: la carne deve cuocersi sminuzzandosi il più possibile, assorbendo tutti i liquidi della marinatura. Continuiamo la cottura fino a quando il sughetto sul fondo non si sarà quasi completamente asciugato, lasciando il macinato saporito e ben sgranato. Ora arriva il momento più divertente: l'assemblaggio. Prepariamo una ciotola capiente creando una base soffice di riso bianco. Disponiamo le uova strapazzate su una metà della ciotola e il macinato di pollo sull'altra metà. Per separare queste due \"tifoserie\", creiamo una coreografica linea di demarcazione centrale utilizzando i piselli sbollentati. Infine, per dare un tocco di acidità che pulisce il palato e un accento di colore rosso vivo, adagiamo al centro un ciuffetto di beni shoga. Il vostro Soboro Don è pronto per essere ammirato e, soprattutto, divorato!",
+    "videoIds": [
+      "K7zTH4QJgds"
+    ]
   },
   "ricette/riso/takenoko_gohan": {
     "docId": "ricette/riso/takenoko_gohan",
@@ -977,7 +1063,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 foglio piccolo di Aburaage (tofu fritto sottile)",
       "Qualche foglia di Kinome (germogli di pepe sansho) per guarnire (opzionale)"
     ],
-    "instructionsText": ""
+    "instructionsText": "",
+    "videoIds": []
   },
   "ricette/riso/takenoko_to_aburaage_takikomi_gohan": {
     "docId": "ricette/riso/takenoko_to_aburaage_takikomi_gohan",
@@ -1004,7 +1091,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Acqua q.b.",
       "Cipollotto verde (Negi)"
     ],
-    "instructionsText": "Per prima cosa ci occupiamo del tofu fritto, che necessita di un passaggio specifico: va lavato abbondantemente con acqua bollente, poi va strizzato con le mani e ben asciugato con della carta assorbente per fargli perdere tutto l'olio in eccesso. Una volta sgrassato, lo tagliamo a fettine sottili. Procediamo tagliando a fette anche il germoglio di bambù e immergiamo la parte verde del cipollotto tagliata a rondelle in una ciotola con acqua e ghiaccio. Passiamo alla preparazione del riso: utilizziamo un misurino preciso di varietà originario e lo laviamo più volte, scolandolo e massaggiandolo sotto l'acqua, finché l'acqua di risciacquo non diventerà completamente trasparente. Quando siamo soddisfatti del risultato, scoliamo bene il riso. Nello stesso misurino del riso uniamo la salsa di soia, il mirin, il sake e il dashi in polvere. A questa miscela di sapori aggiungiamo dell'acqua fresca fino a raggiungere lo stesso esatto volume del riso utilizzato in partenza. Se vogliamo fare più porzioni, basta moltiplicare tutto per il numero di misurini di riso che vogliamo cuocere. A questo punto componiamo il piatto direttamente nel cestello del cuociriso: inseriamo sul fondo il riso pulito, versiamo tutto il liquido e disponiamo sulla superficie i pezzetti di bambù e tofu fritto. Avviamo la cottura e lasciamo compiere la magia. Una volta terminata la cottura, apriamo il coperchio e diamo una bella mescolata al riso, portando in superficie la crosticina che si sarà formata sul fondo. Non ci resta che impiattare in una ciotola, guarnire con le magiche cipolline scolate dall'acqua e ghiaccio, e gustare."
+    "instructionsText": "Per prima cosa ci occupiamo del tofu fritto, che necessita di un passaggio specifico: va lavato abbondantemente con acqua bollente, poi va strizzato con le mani e ben asciugato con della carta assorbente per fargli perdere tutto l'olio in eccesso. Una volta sgrassato, lo tagliamo a fettine sottili. Procediamo tagliando a fette anche il germoglio di bambù e immergiamo la parte verde del cipollotto tagliata a rondelle in una ciotola con acqua e ghiaccio. Passiamo alla preparazione del riso: utilizziamo un misurino preciso di varietà originario e lo laviamo più volte, scolandolo e massaggiandolo sotto l'acqua, finché l'acqua di risciacquo non diventerà completamente trasparente. Quando siamo soddisfatti del risultato, scoliamo bene il riso. Nello stesso misurino del riso uniamo la salsa di soia, il mirin, il sake e il dashi in polvere. A questa miscela di sapori aggiungiamo dell'acqua fresca fino a raggiungere lo stesso esatto volume del riso utilizzato in partenza. Se vogliamo fare più porzioni, basta moltiplicare tutto per il numero di misurini di riso che vogliamo cuocere. A questo punto componiamo il piatto direttamente nel cestello del cuociriso: inseriamo sul fondo il riso pulito, versiamo tutto il liquido e disponiamo sulla superficie i pezzetti di bambù e tofu fritto. Avviamo la cottura e lasciamo compiere la magia. Una volta terminata la cottura, apriamo il coperchio e diamo una bella mescolata al riso, portando in superficie la crosticina che si sarà formata sul fondo. Non ci resta che impiattare in una ciotola, guarnire con le magiche cipolline scolate dall'acqua e ghiaccio, e gustare.",
+    "videoIds": [
+      "2_bqX5GQij0"
+    ]
   },
   "ricette/riso/takikomi_gohan": {
     "docId": "ricette/riso/takikomi_gohan",
@@ -1028,7 +1118,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Mezza carota a julienne",
       "pollo/tonno in scatola/varie ed eventuali"
     ],
-    "instructionsText": "Quando lavi il riso poi lascialo a bagno una mezz’ora e poi un quarto d’ora ad asciugare: assorbira’ meglio il condimento Metti gli shiitake a mollo nel dashi tiepido, dopo mezz’ora filtra il tutto, otterrai lo shiitake dashi. Nella risiera metti il riso, il sale (non te lo scordare, molto poco ma ci vuole) la soia e il mirin, lo shiitake dashi (deve essere della stessa quantita’ in volume del riso) e mischia bene, fai depositare il riso e poi sopra metti, a strati, gli ingredienti, dal più duro al piu’ morbido. Accendi la risiera e non toccare, gira solo quando ha finito, e vedrai che ti mangi."
+    "instructionsText": "Quando lavi il riso poi lascialo a bagno una mezz’ora e poi un quarto d’ora ad asciugare: assorbira’ meglio il condimento Metti gli shiitake a mollo nel dashi tiepido, dopo mezz’ora filtra il tutto, otterrai lo shiitake dashi. Nella risiera metti il riso, il sale (non te lo scordare, molto poco ma ci vuole) la soia e il mirin, lo shiitake dashi (deve essere della stessa quantita’ in volume del riso) e mischia bene, fai depositare il riso e poi sopra metti, a strati, gli ingredienti, dal più duro al piu’ morbido. Accendi la risiera e non toccare, gira solo quando ha finito, e vedrai che ti mangi.",
+    "videoIds": []
   },
   "ricette/sides/bieta_gialla_ohitashi": {
     "docId": "ricette/sides/bieta_gialla_ohitashi",
@@ -1045,7 +1136,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di Salsa di soia (Shoyu)",
       "Sale q.b."
     ],
-    "instructionsText": "Per prima cosa, portiamo a bollore abbondante acqua e la saliamo generosamente. La bieta ha consistenze diverse tra gambo e foglia, quindi richiede una cottura scaglionata. Immergiamo prima i gambi nell'acqua bollente tenendo le foglie fuori, calcolando circa 30-40 secondi. Trascorso questo tempo, spingiamo sotto anche tutta la parte fogliare e proseguiamo la cottura per altri 30 secondi. La verdura deve rimanere croccante e \"al dente\". Scoliamo la bieta e la tuffiamo immediatamente in una ciotola piena di acqua e ghiaccio. Questo passaggio fondamentale serve a fermare la cottura e a far raffreddare benissimo le foglie, fissando un colore verde brillante (e un giallo acceso per i gambi). Una volta fredda, allineiamo le foglie in modo ordinato e procediamo a strizzarle con molta cura. Partendo dai gambi e scendendo verso le punte, applichiamo un movimento \"strizzatorio\" deciso per eliminare tutta l'acqua in eccesso, che altrimenti annacquerebbe il condimento. Disponiamo la bieta compatta su un tagliere e la tagliamo in porzioni uguali, calcolando la misura in base al contenitore di vetro in cui la faremo riposare. Adagiamo i mazzetti tagliati nel contenitore con delicatezza e ordine. A parte, prepariamo la marinatura unendo il dashi, il mirin e la salsa di soia, assaggiando e correggendo le dosi a seconda del proprio gusto. Versiamo questo liquido sulle verdure in modo da coprirle. Per assicurarci che tutta la bieta resti uniformemente a contatto con il liquido, copriamo la superficie con un panno di carta da cucina, che si inzupperà fungendo da coperchio a contatto. Chiudiamo il contenitore e lasciamo riposare in frigorifero per qualche ora. Al momento di servire, con la pazienza di un giocatore di shangai, preleviamo i mazzetti e li disponiamo in maniera fotogenica in una ciotolina, ricordandoci di versare sopra qualche cucchiaio del loro squisito brodino freddo."
+    "instructionsText": "Per prima cosa, portiamo a bollore abbondante acqua e la saliamo generosamente. La bieta ha consistenze diverse tra gambo e foglia, quindi richiede una cottura scaglionata. Immergiamo prima i gambi nell'acqua bollente tenendo le foglie fuori, calcolando circa 30-40 secondi. Trascorso questo tempo, spingiamo sotto anche tutta la parte fogliare e proseguiamo la cottura per altri 30 secondi. La verdura deve rimanere croccante e \"al dente\". Scoliamo la bieta e la tuffiamo immediatamente in una ciotola piena di acqua e ghiaccio. Questo passaggio fondamentale serve a fermare la cottura e a far raffreddare benissimo le foglie, fissando un colore verde brillante (e un giallo acceso per i gambi). Una volta fredda, allineiamo le foglie in modo ordinato e procediamo a strizzarle con molta cura. Partendo dai gambi e scendendo verso le punte, applichiamo un movimento \"strizzatorio\" deciso per eliminare tutta l'acqua in eccesso, che altrimenti annacquerebbe il condimento. Disponiamo la bieta compatta su un tagliere e la tagliamo in porzioni uguali, calcolando la misura in base al contenitore di vetro in cui la faremo riposare. Adagiamo i mazzetti tagliati nel contenitore con delicatezza e ordine. A parte, prepariamo la marinatura unendo il dashi, il mirin e la salsa di soia, assaggiando e correggendo le dosi a seconda del proprio gusto. Versiamo questo liquido sulle verdure in modo da coprirle. Per assicurarci che tutta la bieta resti uniformemente a contatto con il liquido, copriamo la superficie con un panno di carta da cucina, che si inzupperà fungendo da coperchio a contatto. Chiudiamo il contenitore e lasciamo riposare in frigorifero per qualche ora. Al momento di servire, con la pazienza di un giocatore di shangai, preleviamo i mazzetti e li disponiamo in maniera fotogenica in una ciotolina, ricordandoci di versare sopra qualche cucchiaio del loro squisito brodino freddo.",
+    "videoIds": [
+      "GSGDzrBpbUQ"
+    ]
   },
   "ricette/sides/burokkori_no_okaka-ae": {
     "docId": "ricette/sides/burokkori_no_okaka-ae",
@@ -1066,7 +1160,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sesamo tostato q.b.",
       "Katsuobushi (fiocchi di tonnetto essiccato) in abbondanza"
     ],
-    "instructionsText": "Iniziamo dividendo i broccoli in cimette di dimensioni omogenee. Per la cottura tradizionale, sbollentiamo i broccoli in acqua per un paio di minuti: l'obiettivo è ammorbidirli leggermente mantenendoli però ben croccanti e tenaci al morso. Il passaggio fondamentale arriva subito dopo la scolatura: i broccoli caldi vanno letteralmente fiondati in una ciotola con acqua e ghiaccio. Questo shock termico serve a fermare immediatamente la cottura, fissare la loro naturale croccantezza e, soprattutto, a preservare quella meravigliosa \"verdosità\" e brillantezza che rende il piatto appagante anche alla vista. Una volta ben freddi, scoliamoli accuratamente e trasferiamoli in una ciotola capiente. Passiamo al condimento: aggiungiamo un cucchiaio di salsa di soia e un cucchiaio di olio di sesamo. Quest'ultimo non fa parte della ricetta canonica e tradizionale, ma regala una spinta aromatica che si sposa divinamente con gli altri sapori. Sgrattugiamo abbondante sesamo tostato direttamente sui broccoli e, infine, aggiungiamo il vero protagonista del piatto: una generosa manciata di katsuobushi. Diamo una bella mescolata per distribuire uniformemente i sapori e serviamo su un bel piatto di portata."
+    "instructionsText": "Iniziamo dividendo i broccoli in cimette di dimensioni omogenee. Per la cottura tradizionale, sbollentiamo i broccoli in acqua per un paio di minuti: l'obiettivo è ammorbidirli leggermente mantenendoli però ben croccanti e tenaci al morso. Il passaggio fondamentale arriva subito dopo la scolatura: i broccoli caldi vanno letteralmente fiondati in una ciotola con acqua e ghiaccio. Questo shock termico serve a fermare immediatamente la cottura, fissare la loro naturale croccantezza e, soprattutto, a preservare quella meravigliosa \"verdosità\" e brillantezza che rende il piatto appagante anche alla vista. Una volta ben freddi, scoliamoli accuratamente e trasferiamoli in una ciotola capiente. Passiamo al condimento: aggiungiamo un cucchiaio di salsa di soia e un cucchiaio di olio di sesamo. Quest'ultimo non fa parte della ricetta canonica e tradizionale, ma regala una spinta aromatica che si sposa divinamente con gli altri sapori. Sgrattugiamo abbondante sesamo tostato direttamente sui broccoli e, infine, aggiungiamo il vero protagonista del piatto: una generosa manciata di katsuobushi. Diamo una bella mescolata per distribuire uniformemente i sapori e serviamo su un bel piatto di portata.",
+    "videoIds": [
+      "gCil7EuAVMU"
+    ]
   },
   "ricette/sides/horenso_no_ohitashi": {
     "docId": "ricette/sides/horenso_no_ohitashi",
@@ -1084,7 +1181,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 mazzi di Spinaci",
       "1 cucchiaino colmo di Sale (per la bollitura)"
     ],
-    "instructionsText": ""
+    "instructionsText": "",
+    "videoIds": []
   },
   "ricette/sides/mugen_oba_nasu": {
     "docId": "ricette/sides/mugen_oba_nasu",
@@ -1102,7 +1200,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "5 foglie di Shiso",
       "1 cucchiaio di Olio vegetale"
     ],
-    "instructionsText": "In una ciotola capiente, unire tutti gli ingredienti per la salsa: salsa di soia, aceto, zucchero, brodo granulare, aglio, zenzero e semi di sesamo. Mescolare bene e mettere da parte. Rimuovere il gambo dalle foglie di shiso e tagliarle a julienne. Tagliare le melanzane: rimuovere il picciolo, dividerle a metà per il lungo e poi tagliare ogni metà in 3 o 4 spicchi a forma di ventaglio. Immergere gli spicchi in acqua per 5-10 minuti per eliminare l'amaro, quindi scolarli e asciugarli molto bene. Mettere le melanzane asciutte in una padella, aggiungere l'olio e mescolare per ungerle uniformemente. Cuocere a fuoco medio, prima dal lato della buccia e poi su tutti i lati, finché non saranno tenere e ben dorate. Trasferire le melanzane ancora calde direttamente nella ciotola con la salsa. Aggiungere la maggior parte dello shiso (tenendone un po' da parte per la guarnizione) e mescolare bene il tutto. Impiattare subito e guarnire con lo shiso rimasto."
+    "instructionsText": "In una ciotola capiente, unire tutti gli ingredienti per la salsa: salsa di soia, aceto, zucchero, brodo granulare, aglio, zenzero e semi di sesamo. Mescolare bene e mettere da parte. Rimuovere il gambo dalle foglie di shiso e tagliarle a julienne. Tagliare le melanzane: rimuovere il picciolo, dividerle a metà per il lungo e poi tagliare ogni metà in 3 o 4 spicchi a forma di ventaglio. Immergere gli spicchi in acqua per 5-10 minuti per eliminare l'amaro, quindi scolarli e asciugarli molto bene. Mettere le melanzane asciutte in una padella, aggiungere l'olio e mescolare per ungerle uniformemente. Cuocere a fuoco medio, prima dal lato della buccia e poi su tutti i lati, finché non saranno tenere e ben dorate. Trasferire le melanzane ancora calde direttamente nella ciotola con la salsa. Aggiungere la maggior parte dello shiso (tenendone un po' da parte per la guarnizione) e mescolare bene il tutto. Impiattare subito e guarnire con lo shiso rimasto.",
+    "videoIds": []
   },
   "ricette/sides/nametake": {
     "docId": "ricette/sides/nametake",
@@ -1125,7 +1224,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di Zucchero",
       "1 cucchiaio di Aceto di Riso"
     ],
-    "instructionsText": "Per iniziare, prendi il mazzetto di funghi Enoki e rimuovi con un coltello la base del cespo (la parte con le radici), quindi taglia i funghi restanti in tre parti uguali. Trasferisci tutto in un pentolino e aggiungi direttamente a freddo i condimenti: la salsa di soia, il mirin, il sake e il cucchiaino di zucchero. Accendi il fornello e fai cuocere a fuoco medio per circa 5 minuti, mescolando di tanto in tanto; noterai che i funghi rilasceranno la loro acqua e si ammorbidiranno rapidamente. Quando la salsa di cottura si sarà leggermente ritirata e addensata, versa un cucchiaio di aceto di riso e lascia andare sul fuoco ancora per un paio di minuti per far amalgamare bene i sapori. A questo punto il Nametake è pronto: puoi servirlo immediatamente sopra una ciotola di riso fumante o trasferirlo in un barattolo per conservarlo in frigorifero."
+    "instructionsText": "Per iniziare, prendi il mazzetto di funghi Enoki e rimuovi con un coltello la base del cespo (la parte con le radici), quindi taglia i funghi restanti in tre parti uguali. Trasferisci tutto in un pentolino e aggiungi direttamente a freddo i condimenti: la salsa di soia, il mirin, il sake e il cucchiaino di zucchero. Accendi il fornello e fai cuocere a fuoco medio per circa 5 minuti, mescolando di tanto in tanto; noterai che i funghi rilasceranno la loro acqua e si ammorbidiranno rapidamente. Quando la salsa di cottura si sarà leggermente ritirata e addensata, versa un cucchiaio di aceto di riso e lascia andare sul fuoco ancora per un paio di minuti per far amalgamare bene i sapori. A questo punto il Nametake è pronto: puoi servirlo immediatamente sopra una ciotola di riso fumante o trasferirlo in un barattolo per conservarlo in frigorifero.",
+    "videoIds": []
   },
   "ricette/sides/nasu_dengaku": {
     "docId": "ricette/sides/nasu_dengaku",
@@ -1140,7 +1240,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     ],
     "recipeYield": null,
     "recipeIngredient": [],
-    "instructionsText": "Metti subito a scaldare il grill del forno Tagliare la melanzana in 2, e inciderla a losanga (profondità’ 4-5 mm) per farla cuocere più’ uniformemente Mettere le melanzane in una padella con poco olio (arachide o girasole) caldo, dal lato della pelle, e farle cuocere senza coperchio per 2-3 minuti, girarle e farle cuocere dall’altro lato per altri 2-3 minuti. Se sono molto spesse mettere il coperchio. Mettere le melanzane in una teglia e spennellarle con la glassatura di miso, finire la cottura in forno con il grill al massimo, per 5 minuti o finche non sono dorate Vacci piano col miso che senno’ ti vengono salate Guarnire con negi (o cipolline)"
+    "instructionsText": "Metti subito a scaldare il grill del forno Tagliare la melanzana in 2, e inciderla a losanga (profondità’ 4-5 mm) per farla cuocere più’ uniformemente Mettere le melanzane in una padella con poco olio (arachide o girasole) caldo, dal lato della pelle, e farle cuocere senza coperchio per 2-3 minuti, girarle e farle cuocere dall’altro lato per altri 2-3 minuti. Se sono molto spesse mettere il coperchio. Mettere le melanzane in una teglia e spennellarle con la glassatura di miso, finire la cottura in forno con il grill al massimo, per 5 minuti o finche non sono dorate Vacci piano col miso che senno’ ti vengono salate Guarnire con negi (o cipolline)",
+    "videoIds": []
   },
   "ricette/sides/nasu_no_yaki-bitashi": {
     "docId": "ricette/sides/nasu_no_yaki-bitashi",
@@ -1156,7 +1257,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     ],
     "recipeYield": null,
     "recipeIngredient": [],
-    "instructionsText": "Preparare il brodo di marinatura mescolando in una caraffa l'acqua, la salsa di soia, il mirin, lo zucchero, il dashi in polvere e lo zenzero grattugiato. Lavare e asciugare molto bene le melanzane. Rimuovere il picciolo e tagliarle a metà per il lungo. Con un coltello, incidere la superficie della buccia con tagli diagonali poco profondi, per favorire la cottura e l'assorbimento del sapore. Disporre le melanzane in una padella capiente. Spennellarle uniformemente su tutta la superficie (prima la buccia, poi la polpa) con i due cucchiai di olio. Cuocere a fuoco medio con la buccia rivolta verso il basso per circa 2-3 minuti. Girare le melanzane, abbassare la fiamma al minimo, coprire con un coperchio e cuocere lentamente finché la polpa non sarà tenera e ben dorata. Versare il brodo preparato direttamente nella padella sopra le melanzane. Alzare la fiamma a fuoco medio e portare a ebollizione. Appena il liquido bolle, spegnere immediatamente il fuoco. Trasferire con delicatezza le melanzane e tutto il loro brodo in un contenitore per alimenti. Lasciare raffreddare completamente a temperatura ambiente, dopodiché coprire e riporre in frigorifero a insaporire per almeno 3 ore. Servire le melanzane fredde, irrorandole con il loro brodo di marinatura e guarnendo a piacere con foglie di shiso tritate o katsuobushi."
+    "instructionsText": "Preparare il brodo di marinatura mescolando in una caraffa l'acqua, la salsa di soia, il mirin, lo zucchero, il dashi in polvere e lo zenzero grattugiato. Lavare e asciugare molto bene le melanzane. Rimuovere il picciolo e tagliarle a metà per il lungo. Con un coltello, incidere la superficie della buccia con tagli diagonali poco profondi, per favorire la cottura e l'assorbimento del sapore. Disporre le melanzane in una padella capiente. Spennellarle uniformemente su tutta la superficie (prima la buccia, poi la polpa) con i due cucchiai di olio. Cuocere a fuoco medio con la buccia rivolta verso il basso per circa 2-3 minuti. Girare le melanzane, abbassare la fiamma al minimo, coprire con un coperchio e cuocere lentamente finché la polpa non sarà tenera e ben dorata. Versare il brodo preparato direttamente nella padella sopra le melanzane. Alzare la fiamma a fuoco medio e portare a ebollizione. Appena il liquido bolle, spegnere immediatamente il fuoco. Trasferire con delicatezza le melanzane e tutto il loro brodo in un contenitore per alimenti. Lasciare raffreddare completamente a temperatura ambiente, dopodiché coprire e riporre in frigorifero a insaporire per almeno 3 ore. Servire le melanzane fredde, irrorandole con il loro brodo di marinatura e guarnendo a piacere con foglie di shiso tritate o katsuobushi.",
+    "videoIds": []
   },
   "ricette/sides/potetosarada": {
     "docId": "ricette/sides/potetosarada",
@@ -1184,7 +1286,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale qb",
       "Pepe qb"
     ],
-    "instructionsText": "Mettere a bollire le patate. Tagliare il cetriolo e la cipolla sottilissimi, metterli in uno scolapasta con un po' di sale e metterci sopra un canovaccio con un peso. Far drenare per 15-20 minuti. Dopo, eliminare il sale in eccesso (anche con una sciaquata veloce) e strizzare bene con un canovaccio (mi raccomando bene) Sbollentare le carota sbucciate per qualche minuto, poi tagliarle a fettine o cubetti (come prederite) Una volta che le patate sono pronte, sbucciarle senza scottarsi, metterle in una terrina e schiacciarle con una forchetta come per fare il pure', lasciando dei pezzetti per avere una consistenza piu' varia (aho poi a me piacciono cosi poi voi fate come vi pare) Aggiungere cetriolo, cipolla, carota, la maionese, il mirin e l'aceto di riso, lo zucchero, il sale e il pepe e mescolare. I condimenti finali vanno un po' a piacere, soprattutto per quanto riguarda lo zucchero."
+    "instructionsText": "Mettere a bollire le patate. Tagliare il cetriolo e la cipolla sottilissimi, metterli in uno scolapasta con un po' di sale e metterci sopra un canovaccio con un peso. Far drenare per 15-20 minuti. Dopo, eliminare il sale in eccesso (anche con una sciaquata veloce) e strizzare bene con un canovaccio (mi raccomando bene) Sbollentare le carota sbucciate per qualche minuto, poi tagliarle a fettine o cubetti (come prederite) Una volta che le patate sono pronte, sbucciarle senza scottarsi, metterle in una terrina e schiacciarle con una forchetta come per fare il pure', lasciando dei pezzetti per avere una consistenza piu' varia (aho poi a me piacciono cosi poi voi fate come vi pare) Aggiungere cetriolo, cipolla, carota, la maionese, il mirin e l'aceto di riso, lo zucchero, il sale e il pepe e mescolare. I condimenti finali vanno un po' a piacere, soprattutto per quanto riguarda lo zucchero.",
+    "videoIds": []
   },
   "ricette/sides/unagi-di-melanzane": {
     "docId": "ricette/sides/unagi-di-melanzane",
@@ -1215,7 +1318,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Semi di sesamo tostati per guarnire",
       "Cipolline verdi per guarnire"
     ],
-    "instructionsText": "Sbucciare una striscia sì e una striscia no (come la divisa della Juve). Poi incartarla in un foglio di carta da cucina bagnato e strizzato, e poi nella pellicola per alimenti. Così avvolta, metterla in un microonde per 2-3 minuti alla massima potenza per accelerare la cottura. Scartarla e, con una forchetta, incidere dei solchi sulla polpa nel senso della lunghezza per imitare la consistenza di un'anguilla. Dopodiché, spennellarla con della fecola di patate, spennellando via l'eccesso. La salsa di cottura: In una ciotolina prepariamo la salsa mescolando sakè, mirin, salsa di soia e lo zucchero. In padella!: Metterla in una padella con un filo d'olio di semi e ripassarla a fuoco medio da ambo i lati, per farla diventare fuori croccantissima e dentro morbidissima. La glassatura: A questo punto, le concediamo un bel bagnetto versando la salsa di cottura direttamente in padella. A fuoco lentissimo, lasciamo che la salsa si riduca e glassi la melanzana. Ecco la trasformazione. Il gran finale: \"Sono un'anguilla, sono un'anguilla!\" gridava la nostra melanzana. E le fu preparato un letto di riso trionfale su cui fu dolcemente adagiata. Per guarnirla, come farle mancare dei semi di sesamo appena tostati e delle gloriose cipolline verdi? E la nostra melanzana è diventata un'anguilla."
+    "instructionsText": "Sbucciare una striscia sì e una striscia no (come la divisa della Juve). Poi incartarla in un foglio di carta da cucina bagnato e strizzato, e poi nella pellicola per alimenti. Così avvolta, metterla in un microonde per 2-3 minuti alla massima potenza per accelerare la cottura. Scartarla e, con una forchetta, incidere dei solchi sulla polpa nel senso della lunghezza per imitare la consistenza di un'anguilla. Dopodiché, spennellarla con della fecola di patate, spennellando via l'eccesso. La salsa di cottura: In una ciotolina prepariamo la salsa mescolando sakè, mirin, salsa di soia e lo zucchero. In padella!: Metterla in una padella con un filo d'olio di semi e ripassarla a fuoco medio da ambo i lati, per farla diventare fuori croccantissima e dentro morbidissima. La glassatura: A questo punto, le concediamo un bel bagnetto versando la salsa di cottura direttamente in padella. A fuoco lentissimo, lasciamo che la salsa si riduca e glassi la melanzana. Ecco la trasformazione. Il gran finale: \"Sono un'anguilla, sono un'anguilla!\" gridava la nostra melanzana. E le fu preparato un letto di riso trionfale su cui fu dolcemente adagiata. Per guarnirla, come farle mancare dei semi di sesamo appena tostati e delle gloriose cipolline verdi? E la nostra melanzana è diventata un'anguilla.",
+    "videoIds": []
   },
   "ricette/tsukemono/daikon": {
     "docId": "ricette/tsukemono/daikon",
@@ -1237,7 +1341,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di sale marino in fiocchi o mezzo cuucchiaio di sale in polvere",
       "⅓ cup sugar (provato con 2 cucchiai grandi)"
     ],
-    "instructionsText": "Taglia il daikon a meta', e poi a fettine di 5mm circa di spessore, ottenendo delle mezze lune. Mischia tutto molto bene e metti in un sacchetto di plastica a chiusura ermetica, cercando di far uscire tutta l'aria. All'inizio il liquido di marinatura sembrera' un po' poco, ma con il tempo il daikon, grazie al sale, espellera' un sacco di acqua. Metti in frigorifero, e' buono dopo 2-3 ore, ma suggerisco di aspettare almeno una settimana. Non ho idea di quanto si conservi, ma ne ho trovato uno dimenticato in frigo da mesi, ed era il migliore che avessi provato (e sono ancora vivo mesi dopo). Suppongo che se vada a male, sia anche facile accorgersene."
+    "instructionsText": "Taglia il daikon a meta', e poi a fettine di 5mm circa di spessore, ottenendo delle mezze lune. Mischia tutto molto bene e metti in un sacchetto di plastica a chiusura ermetica, cercando di far uscire tutta l'aria. All'inizio il liquido di marinatura sembrera' un po' poco, ma con il tempo il daikon, grazie al sale, espellera' un sacco di acqua. Metti in frigorifero, e' buono dopo 2-3 ore, ma suggerisco di aspettare almeno una settimana. Non ho idea di quanto si conservi, ma ne ho trovato uno dimenticato in frigo da mesi, ed era il migliore che avessi provato (e sono ancora vivo mesi dopo). Suppongo che se vada a male, sia anche facile accorgersene.",
+    "videoIds": []
   },
   "ricette/tsukemono/daikon_shiokombuzuke": {
     "docId": "ricette/tsukemono/daikon_shiokombuzuke",
@@ -1262,7 +1367,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiai di Shoyu (salsa di soia)",
       "1 cucchiaio di Zucchero"
     ],
-    "instructionsText": "Per prima cosa, prepara il daikon: taglialo in pezzi lunghi circa 6-7 cm, poi affettalo e ricavane delle listarelle. Metti le listarelle in una ciotola capiente e aggiungi il sale (\"copioso\", circa due cucchiai per mezzo chilo di daikon). Mischia bene con le mani per distribuirlo ovunque. Trasferisci il tutto in un colino, posiziona un piattino con un peso sopra (un barattolo pieno d'acqua va benissimo) e lascia riposare per circa mezz'ora. Il daikon rilascerà moltissima acqua. Passata la mezz'ora, sciacqua velocemente il daikon sotto l'acqua corrente per rimuovere il sale in eccesso. Ora la parte fondamentale: strizzalo con forza! Prendi un barattolo di vetro e inizia a comporre gli strati alternando: 1. Una dose di Daikon strizzato; 2. Una presa di Shio Kombu (l'ingrediente segreto, una vera bomba umami); 3. Un po' di peperoncino. Ripeti fino a riempire il barattolo. Per il condimento finale, versa nel barattolo: l'olio di sesamo, la salsa di soia e lo zucchero. Chiudi il barattolo e agita energicamente per amalgamare tutto. Metti in frigorifero. Sebbene basti qualche ora, lasciarlo riposare una notte intera è il top per far insaporire bene il tutto. Si conserva per qualche giorno, ma è così buono che finirà subito! Itadakimasu!"
+    "instructionsText": "Per prima cosa, prepara il daikon: taglialo in pezzi lunghi circa 6-7 cm, poi affettalo e ricavane delle listarelle. Metti le listarelle in una ciotola capiente e aggiungi il sale (\"copioso\", circa due cucchiai per mezzo chilo di daikon). Mischia bene con le mani per distribuirlo ovunque. Trasferisci il tutto in un colino, posiziona un piattino con un peso sopra (un barattolo pieno d'acqua va benissimo) e lascia riposare per circa mezz'ora. Il daikon rilascerà moltissima acqua. Passata la mezz'ora, sciacqua velocemente il daikon sotto l'acqua corrente per rimuovere il sale in eccesso. Ora la parte fondamentale: strizzalo con forza! Prendi un barattolo di vetro e inizia a comporre gli strati alternando: 1. Una dose di Daikon strizzato; 2. Una presa di Shio Kombu (l'ingrediente segreto, una vera bomba umami); 3. Un po' di peperoncino. Ripeti fino a riempire il barattolo. Per il condimento finale, versa nel barattolo: l'olio di sesamo, la salsa di soia e lo zucchero. Chiudi il barattolo e agita energicamente per amalgamare tutto. Metti in frigorifero. Sebbene basti qualche ora, lasciarlo riposare una notte intera è il top per far insaporire bene il tutto. Si conserva per qualche giorno, ma è così buono che finirà subito! Itadakimasu!",
+    "videoIds": [
+      "OoqRYJGzWmA"
+    ]
   },
   "ricette/tsukemono/gari": {
     "docId": "ricette/tsukemono/gari",
@@ -1276,7 +1384,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "250g zenzero fresco",
       "1 cucchiaino di sale fino"
     ],
-    "instructionsText": "Sbuccia lo zenzero raschiandolo con un cucchiaio, e lavalo con acqua fredda. Taglialo a fettine sottili, usando un pelapatate o una mandolina, e mettile in una ciotola. Aggiungi un cucchiaio di sale e lascia riposare per 10 minuti, viene meglio ancora se lo metti sotto un peso per far rilasciare il liquido. Intanto metti una pentola con l'acqua sul fuoco, e porta a bollore. Strizza bene lo zenzero, e mettilo a bollire per 1-2 minuti. Se lo zenzero e' molto piccante, puoi bollirlo per 2-3 minuti. Scolalo bene e distribuiscilo su un panno pulito, e lascialo asciugare finche' non si fredda completamente. Strizzalo bene e mettilo in un barattolo di vetro sterilizzato. Mentre lo zenzero asciuga, prepara l'amazu. Metti l'aceto, lo zucchero e il sale in una pentola, e porta a bollore. Lascia bollire per 1-2 minuti, finche' lo zucchero non si e' sciolto completamente. Lascia raffreddare completamente. Versa l'amazu sullo zenzero, e lascia riposare per 1-2 giorni prima di consumarlo. Si conserva per mesi in frigo."
+    "instructionsText": "Sbuccia lo zenzero raschiandolo con un cucchiaio, e lavalo con acqua fredda. Taglialo a fettine sottili, usando un pelapatate o una mandolina, e mettile in una ciotola. Aggiungi un cucchiaio di sale e lascia riposare per 10 minuti, viene meglio ancora se lo metti sotto un peso per far rilasciare il liquido. Intanto metti una pentola con l'acqua sul fuoco, e porta a bollore. Strizza bene lo zenzero, e mettilo a bollire per 1-2 minuti. Se lo zenzero e' molto piccante, puoi bollirlo per 2-3 minuti. Scolalo bene e distribuiscilo su un panno pulito, e lascialo asciugare finche' non si fredda completamente. Strizzalo bene e mettilo in un barattolo di vetro sterilizzato. Mentre lo zenzero asciuga, prepara l'amazu. Metti l'aceto, lo zucchero e il sale in una pentola, e porta a bollore. Lascia bollire per 1-2 minuti, finche' lo zucchero non si e' sciolto completamente. Lascia raffreddare completamente. Versa l'amazu sullo zenzero, e lascia riposare per 1-2 giorni prima di consumarlo. Si conserva per mesi in frigo.",
+    "videoIds": [
+      "eRxAtgrW2CE"
+    ]
   },
   "ricette/tsukemono/kyuri-no-tsukemono": {
     "docId": "ricette/tsukemono/kyuri-no-tsukemono",
@@ -1294,7 +1405,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiaini di Sushisu (aceto per sushi)",
       "1 cucchiaino di senape Karashi (in alternativa, va bene anche la senape comune)"
     ],
-    "instructionsText": "Per prima cosa, preparare il cetriolo. Con la lama di un coltello, raschiare via le asperità dalla buccia. Spargere un po' di sale su un tagliere e massaggiare vigorosamente il cetriolo sul sale per qualche istante. Eliminare il sale in eccesso e inserire il cetriolo (tagliato a metà se necessario) in un sacchetto di plastica per alimenti. Aggiungere nel sacchetto i due cucchiaini di sushisu e il cucchiaino di senape. Per creare un effetto \"sottovuoto dei poveri\", immergere il sacchetto in acqua (lasciando l'apertura fuori) per far uscire tutta l'aria, quindi sigillarlo. Mettere il sacchetto in frigorifero a marinare per qualche ora. Una volta pronto, togliere il cetriolo dal sacchetto, tagliarlo in quarti per il lungo, eliminare i semi interni e poi tagliarlo a tocchetti. Disporre i pezzi su un piattino, condire con un po' del liquido di marinatura avanzato nel sacchetto e servire. Itadakimasu!"
+    "instructionsText": "Per prima cosa, preparare il cetriolo. Con la lama di un coltello, raschiare via le asperità dalla buccia. Spargere un po' di sale su un tagliere e massaggiare vigorosamente il cetriolo sul sale per qualche istante. Eliminare il sale in eccesso e inserire il cetriolo (tagliato a metà se necessario) in un sacchetto di plastica per alimenti. Aggiungere nel sacchetto i due cucchiaini di sushisu e il cucchiaino di senape. Per creare un effetto \"sottovuoto dei poveri\", immergere il sacchetto in acqua (lasciando l'apertura fuori) per far uscire tutta l'aria, quindi sigillarlo. Mettere il sacchetto in frigorifero a marinare per qualche ora. Una volta pronto, togliere il cetriolo dal sacchetto, tagliarlo in quarti per il lungo, eliminare i semi interni e poi tagliarlo a tocchetti. Disporre i pezzi su un piattino, condire con un po' del liquido di marinatura avanzato nel sacchetto e servire. Itadakimasu!",
+    "videoIds": []
   },
   "ricette/tsukemono/ninniku-no-misozuke": {
     "docId": "ricette/tsukemono/ninniku-no-misozuke",
@@ -1314,7 +1426,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "45ml di mirin",
       "3 teste d'aglio"
     ],
-    "instructionsText": "Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro. Tagliare gli spicchi per il lungo e togliere l'anima. Mettere gli spicchi d'aglio su una griglia, e lasciare asciugare tutta la notte. Questo aiuta a concentrare il sapore dell'aglio e a ridurre la quantita' di umidita' al suo interno. Mescolare il miso, il sake e il mirin in un piccolo pentolino, e scaldare mischiando per 2-3 minuti, fiche' non avra' assunto una consistenza liscia, cremosa e uniforme. Mettere il composto alternandolo a strati con l'aglio in un un barattolo. Far fermentare almeno 3 mesi in frigorifero."
+    "instructionsText": "Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro. Tagliare gli spicchi per il lungo e togliere l'anima. Mettere gli spicchi d'aglio su una griglia, e lasciare asciugare tutta la notte. Questo aiuta a concentrare il sapore dell'aglio e a ridurre la quantita' di umidita' al suo interno. Mescolare il miso, il sake e il mirin in un piccolo pentolino, e scaldare mischiando per 2-3 minuti, fiche' non avra' assunto una consistenza liscia, cremosa e uniforme. Mettere il composto alternandolo a strati con l'aglio in un un barattolo. Far fermentare almeno 3 mesi in frigorifero.",
+    "videoIds": []
   },
   "ricette/tsukemono/ninniku-shoyuzuke": {
     "docId": "ricette/tsukemono/ninniku-shoyuzuke",
@@ -1332,7 +1445,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 tazza di salsa di soia",
       "1/2 tazza di aceto di riso"
     ],
-    "instructionsText": "Mettere la salsa di soia, lo zucchero e l'aceto di riso in un pentolino, portare a bollore e spegnere il fuoco. Versare il preparato in un barattolo di vetro sterilizzato insieme all'aglio. Chiudere il barattolo e mettere in frigo. Il composto e' pronto dopo 3-4 settimane (meglio 4-5) e si conserva in frigo almeno 12 settimane."
+    "instructionsText": "Mettere la salsa di soia, lo zucchero e l'aceto di riso in un pentolino, portare a bollore e spegnere il fuoco. Versare il preparato in un barattolo di vetro sterilizzato insieme all'aglio. Chiudere il barattolo e mettere in frigo. Il composto e' pronto dopo 3-4 settimane (meglio 4-5) e si conserva in frigo almeno 12 settimane.",
+    "videoIds": []
   },
   "ricette/yakimono/gyoza": {
     "docId": "ricette/yakimono/gyoza",
@@ -1361,7 +1475,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiai di salsa di soia",
       "2 cucchiai di sake"
     ],
-    "instructionsText": "Tritare finemente il cavolo e metterlo in una ciotola con un cucchiaio di sale. Lasciar riposare per 10 minuti, poi sciacquate e strizzare bene il cavolo per eliminare l'acqua in eccesso. Mentre il cavolo sta li per conto suo a perdere acqua, tritare finemente l'aglio, lo zenzero e le cipolline verdi. Mettere tutto in una ciotola con la carne di maiale e gli altri ingredienti e mescolare finché non si rompono le proteine della carne e il composto diventa omogeneo e quasi colloso. Con un cucchiaino, prendere un po' di ripieno e metterlo al centro di una sfoglia di pasta per gyoza. Bagnare i bordi con un po' d'acqua e chiudere a mezzaluna, facendo delle pieghe a ventaglio. Siccome faccio pena a chiudere i gyoza, vi linko un video di come si chiudono i gyoza: link Mettete i gyoza chiusi su un foglio di carta da forno, cosparso leggermente con della fecola di patate, o amido di mais. Questo non solo evita che i gyoza si attacchino al foglio, ma l'amido, sciogliendosi nell'acqua in cottura, fara' una splendida crosticina dorata. Piu' o meno il risultato e' questo (notare quello in basso a sinistra, detto anche Gyozimodo): !Gyoza"
+    "instructionsText": "Tritare finemente il cavolo e metterlo in una ciotola con un cucchiaio di sale. Lasciar riposare per 10 minuti, poi sciacquate e strizzare bene il cavolo per eliminare l'acqua in eccesso. Mentre il cavolo sta li per conto suo a perdere acqua, tritare finemente l'aglio, lo zenzero e le cipolline verdi. Mettere tutto in una ciotola con la carne di maiale e gli altri ingredienti e mescolare finché non si rompono le proteine della carne e il composto diventa omogeneo e quasi colloso. Con un cucchiaino, prendere un po' di ripieno e metterlo al centro di una sfoglia di pasta per gyoza. Bagnare i bordi con un po' d'acqua e chiudere a mezzaluna, facendo delle pieghe a ventaglio. Siccome faccio pena a chiudere i gyoza, vi linko un video di come si chiudono i gyoza: link Mettete i gyoza chiusi su un foglio di carta da forno, cosparso leggermente con della fecola di patate, o amido di mais. Questo non solo evita che i gyoza si attacchino al foglio, ma l'amido, sciogliendosi nell'acqua in cottura, fara' una splendida crosticina dorata. Piu' o meno il risultato e' questo (notare quello in basso a sinistra, detto anche Gyozimodo): !Gyoza",
+    "videoIds": []
   },
   "ricette/yakimono/isobeyaki": {
     "docId": "ricette/yakimono/isobeyaki",
@@ -1380,7 +1495,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Salsa di soia (Shoyu)",
       "Alga Nori (tagliata a strisce)"
     ],
-    "instructionsText": "Per questa ricetta partiamo dai Kirimochi, i classici blocchetti di mochi duri e rettangolari che si trovano in commercio. Il primo passaggio è la cottura: possiamo usare una griglia a maglia fine (se avete i fornelli a gas) oppure una semplice padella antiaderente. Cuociamo il mochi a fuoco medio. Vedrete che piano piano inizierà a gonfiarsi, dorarsi in superficie e diventare morbido. Una volta grigliato, il Kirimochi cambia nome e diventa Yakimochi (letteralmente \"mochi grigliato\"). Preparate una ciotolina con della salsa di soia. Prendete il mochi caldissimo direttamente dalla griglia e tuffatelo rapidamente nella soia, rigirandolo per farlo insaporire bene su entrambi i lati. Infine, prendete una striscia di alga nori e avvolgetela intorno al mochi ancora caldo: l'alga si attaccherà grazie all'umidità della soia e al calore, permettendovi di afferrarlo con le mani (facendo attenzione a non scottarvi). Ecco a voi l'Isobeyaki, pronto per essere addentato."
+    "instructionsText": "Per questa ricetta partiamo dai Kirimochi, i classici blocchetti di mochi duri e rettangolari che si trovano in commercio. Il primo passaggio è la cottura: possiamo usare una griglia a maglia fine (se avete i fornelli a gas) oppure una semplice padella antiaderente. Cuociamo il mochi a fuoco medio. Vedrete che piano piano inizierà a gonfiarsi, dorarsi in superficie e diventare morbido. Una volta grigliato, il Kirimochi cambia nome e diventa Yakimochi (letteralmente \"mochi grigliato\"). Preparate una ciotolina con della salsa di soia. Prendete il mochi caldissimo direttamente dalla griglia e tuffatelo rapidamente nella soia, rigirandolo per farlo insaporire bene su entrambi i lati. Infine, prendete una striscia di alga nori e avvolgetela intorno al mochi ancora caldo: l'alga si attaccherà grazie all'umidità della soia e al calore, permettendovi di afferrarlo con le mani (facendo attenzione a non scottarvi). Ecco a voi l'Isobeyaki, pronto per essere addentato.",
+    "videoIds": [
+      "4XRlLfW_Wf0"
+    ]
   },
   "ricette/yakimono/shogayaki": {
     "docId": "ricette/yakimono/shogayaki",
@@ -1398,7 +1516,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "4 fettine di arista di maiale, sottili ma non troppo, meno di 1 cm",
       "fecola di patate per infarinare leggermente le fettine"
     ],
-    "instructionsText": "Trita finemente lo zenzero, la mela e la cipolla, poi mescolali insieme agli altri ingredienti della salsa in una ciotola. Fai qualche taglietto sui bordi e sui nervetti delle fettine, come per i saltimbocca, per evitare che si accartoccino in cottura. Infarina leggerissimamente le fettine di maiale con la fecola di patate. Così leggermente che puoi usare un pennello, come fosse cipria. Anzi, meglio dire “incipriare” le fettine piuttosto che infarinarle. Scalda una padella antiaderente con un filo di olio. Metti a rosolare tutte le fettine da un lato per circa un minuto, o poco meno, finché sono ben rosolate. Girale e cuocile dall’altro lato per circa 30 secondi. A questo punto aggiungi la salsa direttamente in padella e lascia cuocere ancora per al massimo un minuto, giusto il tempo che la carne si insaporisca bene. Togli le fettine dalla padella e fai finire di addensare la salsa. Servi gli shogayaki guarnendo con la salsa rimasta."
+    "instructionsText": "Trita finemente lo zenzero, la mela e la cipolla, poi mescolali insieme agli altri ingredienti della salsa in una ciotola. Fai qualche taglietto sui bordi e sui nervetti delle fettine, come per i saltimbocca, per evitare che si accartoccino in cottura. Infarina leggerissimamente le fettine di maiale con la fecola di patate. Così leggermente che puoi usare un pennello, come fosse cipria. Anzi, meglio dire “incipriare” le fettine piuttosto che infarinarle. Scalda una padella antiaderente con un filo di olio. Metti a rosolare tutte le fettine da un lato per circa un minuto, o poco meno, finché sono ben rosolate. Girale e cuocile dall’altro lato per circa 30 secondi. A questo punto aggiungi la salsa direttamente in padella e lascia cuocere ancora per al massimo un minuto, giusto il tempo che la carne si insaporisca bene. Togli le fettine dalla padella e fai finire di addensare la salsa. Servi gli shogayaki guarnendo con la salsa rimasta.",
+    "videoIds": [
+      "kq9OBEQw4E4"
+    ]
   },
   "ricette/yakimono/teriyaki_chicken": {
     "docId": "ricette/yakimono/teriyaki_chicken",
@@ -1415,7 +1536,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "3 cucchiai di Salsa di soia (Shoyu)",
       "Riso bianco al vapore come accompagnamento"
     ],
-    "instructionsText": "La chiave per un ottimo pollo teriyaki risiede nella gestione del calore e del grasso. Iniziamo disponendo la sovracoscia in un pentolino o una padella antiaderente ancora fredda, posizionandola con il lato della pelle verso il basso. Accendiamo il fuoco e lo regoliamo al minimo: il segreto è la lentezza. Lasciamo che il pollo rosoli dolcemente per circa 7-8 minuti; questo permetterà al grasso sottocutaneo di sciogliersi lentamente, rendendo la pelle croccante e sottile. Una volta che la pelle è ben dorata, giriamo il pollo e procediamo con la cottura dell'altro lato. Durante questa fase, è fondamentale utilizzare della carta assorbente per tamponare ed eliminare tutto il grasso in eccesso rilasciato dal pollo nella padella. Questo passaggio è cruciale per evitare che la salsa finale risulti untuosa. Continuiamo la cottura per altri 3-4 minuti fino a quando entrambi i lati saranno ben rosolati, quindi togliamo temporaneamente il pollo dalla padella e lasciamolo riposare. Prepariamo ora la salsa teriyaki nella stessa padella. Versiamo il mirin e il sake, alziamo leggermente la fiamma per far evaporare l'alcol e poi aggiungiamo la salsa di soia. Quando l'intruglio inizia a sobbollire, lasciamolo restringere per circa un minuto. Reintroduciamo il pollo nella padella e iniziamo a glassarlo con cura, girandolo più volte per farlo caramellare uniformemente su tutti i lati. Vogliamo che la salsa diventi splendente e affascinante, avvolgendo il pollo come una lacca. Infine, affettiamo il pollo a striscioline, come farebbe un vero chef di Hokuto, e disponiamolo coreograficamente su un letto di riso bianco al vapore. Non dimentichiamo di versare sopra tutta la salsa rimasta nella padella: sarebbe un delitto sprecarla."
+    "instructionsText": "La chiave per un ottimo pollo teriyaki risiede nella gestione del calore e del grasso. Iniziamo disponendo la sovracoscia in un pentolino o una padella antiaderente ancora fredda, posizionandola con il lato della pelle verso il basso. Accendiamo il fuoco e lo regoliamo al minimo: il segreto è la lentezza. Lasciamo che il pollo rosoli dolcemente per circa 7-8 minuti; questo permetterà al grasso sottocutaneo di sciogliersi lentamente, rendendo la pelle croccante e sottile. Una volta che la pelle è ben dorata, giriamo il pollo e procediamo con la cottura dell'altro lato. Durante questa fase, è fondamentale utilizzare della carta assorbente per tamponare ed eliminare tutto il grasso in eccesso rilasciato dal pollo nella padella. Questo passaggio è cruciale per evitare che la salsa finale risulti untuosa. Continuiamo la cottura per altri 3-4 minuti fino a quando entrambi i lati saranno ben rosolati, quindi togliamo temporaneamente il pollo dalla padella e lasciamolo riposare. Prepariamo ora la salsa teriyaki nella stessa padella. Versiamo il mirin e il sake, alziamo leggermente la fiamma per far evaporare l'alcol e poi aggiungiamo la salsa di soia. Quando l'intruglio inizia a sobbollire, lasciamolo restringere per circa un minuto. Reintroduciamo il pollo nella padella e iniziamo a glassarlo con cura, girandolo più volte per farlo caramellare uniformemente su tutti i lati. Vogliamo che la salsa diventi splendente e affascinante, avvolgendo il pollo come una lacca. Infine, affettiamo il pollo a striscioline, come farebbe un vero chef di Hokuto, e disponiamolo coreograficamente su un letto di riso bianco al vapore. Non dimentichiamo di versare sopra tutta la salsa rimasta nella padella: sarebbe un delitto sprecarla.",
+    "videoIds": [
+      "4urhrkpiV5o"
+    ]
   },
   "ricette/zuppe/misoshiru": {
     "docId": "ricette/zuppe/misoshiru",
@@ -1437,7 +1561,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "negi o porro",
       "altre aggiunte a piacere (opzionale)"
     ],
-    "instructionsText": "Portate il dashi a sfiorare il bollore. Se state preparando una zuppa di miso con verdure, funghi o altri ingredienti, aggiungeteli adesso e portateli a cottura prima del miso. Quando tutto è cotto, spegnete il fuoco e sciogliete il miso nel dashi aiutandovi con un setaccio o con un mestolino. Si può fare anche senza setaccio, ma in questo modo la zuppa resta più liscia e uniforme. Aggiungete il wakame, il tofu e il negi o il porro, poi servite subito."
+    "instructionsText": "Portate il dashi a sfiorare il bollore. Se state preparando una zuppa di miso con verdure, funghi o altri ingredienti, aggiungeteli adesso e portateli a cottura prima del miso. Quando tutto è cotto, spegnete il fuoco e sciogliete il miso nel dashi aiutandovi con un setaccio o con un mestolino. Si può fare anche senza setaccio, ma in questo modo la zuppa resta più liscia e uniforme. Aggiungete il wakame, il tofu e il negi o il porro, poi servite subito.",
+    "videoIds": [
+      "ESa_qRjoKsI"
+    ]
   },
   "ricette/zuppe/osuimono": {
     "docId": "ricette/zuppe/osuimono",
@@ -1459,7 +1586,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "4 tazze di Dashi vegano",
       "Sale q.b."
     ],
-    "instructionsText": "Tagliare il daikon a spicchietti e la carotina a mezze lune. Affettare la cipollina, separando la parte bianca (che andrà in cottura) da quella verde (che terremo da parte per guarnire). Mettere a scaldare il dashi vegano in una pentola. Mi raccomando, aggiungere subito il sale, non ve lo dimenticate! Appena il dashi bolle, buttare dentro tutte le verdurine tagliate: daikon, carota e la parte bianca della cipollina. Chiudere con il coperchio e cuocere per circa 10 minuti. La zuppa sarà pronta quando il daikon diventerà traslucido e stupendo. Servire la zuppa ben calda in una ciotola, guarnire con la parte verde della cipollina e completare con un filo d'olio di sesamo."
+    "instructionsText": "Tagliare il daikon a spicchietti e la carotina a mezze lune. Affettare la cipollina, separando la parte bianca (che andrà in cottura) da quella verde (che terremo da parte per guarnire). Mettere a scaldare il dashi vegano in una pentola. Mi raccomando, aggiungere subito il sale, non ve lo dimenticate! Appena il dashi bolle, buttare dentro tutte le verdurine tagliate: daikon, carota e la parte bianca della cipollina. Chiudere con il coperchio e cuocere per circa 10 minuti. La zuppa sarà pronta quando il daikon diventerà traslucido e stupendo. Servire la zuppa ben calda in una ciotola, guarnire con la parte verde della cipollina e completare con un filo d'olio di sesamo.",
+    "videoIds": []
   },
   "ricette/zuppe/tofu_and_eggs": {
     "docId": "ricette/zuppe/tofu_and_eggs",
@@ -1485,7 +1613,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di Zucchero",
       "1 cucchiaino di Fecola di patate"
     ],
-    "instructionsText": "Preparare il brodo di cottura mescolando in una ciotola il dashi, la salsa di soia, il mirin e lo zucchero. Tagliare le verdure: affettare le carote a julienne, tagliare le cipolline a tocchetti grossolani e affettare i funghi shiitake dopo aver rimosso il gambo. Tagliare il tofu a cubetti non troppo piccoli. Versare il brodo preparato in un pentolino e aggiungere subito i cubetti di tofu, facendo attenzione a non romperli. Coprire e scaldare a fuoco medio per circa 10 minuti, finché non inizia a bollire. Togliere delicatamente il tofu cotto dal pentolino e metterlo da parte in un piatto fondo. Versare tutte le verdure tagliate (carote, funghi e cipolline) nello stesso brodo di cottura, coprire e cuocere per circa 5 minuti. Nel frattempo, sbattere leggermente un uovo in una ciotolina. In un'altra piccola ciotola, sciogliere la fecola di patate con un paio di cucchiai d'acqua fredda. Trascorsi i 5 minuti, versare la fecola sciolta nel pentolino con le verdure e mescolare per addensare leggermente il brodo. Creare un vortice nel brodo e versare a filo l'uovo sbattuto per creare l'effetto \"stracciatella\". Versare le verdure e il brodo sopra il tofu messo da parte nel piatto. La ricetta è pronta, e daje!"
+    "instructionsText": "Preparare il brodo di cottura mescolando in una ciotola il dashi, la salsa di soia, il mirin e lo zucchero. Tagliare le verdure: affettare le carote a julienne, tagliare le cipolline a tocchetti grossolani e affettare i funghi shiitake dopo aver rimosso il gambo. Tagliare il tofu a cubetti non troppo piccoli. Versare il brodo preparato in un pentolino e aggiungere subito i cubetti di tofu, facendo attenzione a non romperli. Coprire e scaldare a fuoco medio per circa 10 minuti, finché non inizia a bollire. Togliere delicatamente il tofu cotto dal pentolino e metterlo da parte in un piatto fondo. Versare tutte le verdure tagliate (carote, funghi e cipolline) nello stesso brodo di cottura, coprire e cuocere per circa 5 minuti. Nel frattempo, sbattere leggermente un uovo in una ciotolina. In un'altra piccola ciotola, sciogliere la fecola di patate con un paio di cucchiai d'acqua fredda. Trascorsi i 5 minuti, versare la fecola sciolta nel pentolino con le verdure e mescolare per addensare leggermente il brodo. Creare un vortice nel brodo e versare a filo l'uovo sbattuto per creare l'effetto \"stracciatella\". Versare le verdure e il brodo sopra il tofu messo da parte nel piatto. La ricetta è pronta, e daje!",
+    "videoIds": []
   },
   "ricette/zuppe/tonjiru": {
     "docId": "ricette/zuppe/tonjiru",
@@ -1518,7 +1647,10 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di Olio di sesamo",
       "Sale q.b."
     ],
-    "instructionsText": ""
+    "instructionsText": "",
+    "videoIds": [
+      "StmMRRErSLQ"
+    ]
   },
   "ricette/zuppe/vegan-misoshiru": {
     "docId": "ricette/zuppe/vegan-misoshiru",
@@ -1539,7 +1671,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Tofu (meglio se tofu morbido o silken tofu)",
       "Cipolline verdi"
     ],
-    "instructionsText": "Mettere in ammollo una manciata di alghe wakame in acqua fredda per farle rinvenire. Tagliare il tofu a cubetti. Portare a bollore il dashi vegano in una pentola. Appena bolle, aggiungere il tofu a cubetti e le alghe wakame reidratate. Cuocere per un paio di minuti. In una ciotolina a parte (o in un mestolo), stemperare il miso con un po' di brodo caldo per scioglierlo bene. È importante farlo a fuoco spento per non rovinare i fermenti. Spegnere il fuoco sotto la pentola e versare il miso sciolto nella zuppa. Mescolare bene. Servire subito in una ciotola e guarnire con delle cipolline fresche tagliate sottili."
+    "instructionsText": "Mettere in ammollo una manciata di alghe wakame in acqua fredda per farle rinvenire. Tagliare il tofu a cubetti. Portare a bollore il dashi vegano in una pentola. Appena bolle, aggiungere il tofu a cubetti e le alghe wakame reidratate. Cuocere per un paio di minuti. In una ciotolina a parte (o in un mestolo), stemperare il miso con un po' di brodo caldo per scioglierlo bene. È importante farlo a fuoco spento per non rovinare i fermenti. Spegnere il fuoco sotto la pentola e versare il miso sciolto nella zuppa. Mescolare bene. Servire subito in una ciotola e guarnire con delle cipolline fresche tagliate sottili.",
+    "videoIds": []
   },
   "ricette/zuppe/zuppa_di_miso_e_funghi": {
     "docId": "ricette/zuppe/zuppa_di_miso_e_funghi",
@@ -1563,6 +1696,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1-2 cucchiai di Miso Rosso (Aka Miso)",
       "Cipollotto (Negi) per guarnire"
     ],
-    "instructionsText": "Questa ricetta si prepara in due fasi: la preparazione del dashi (giorno 1) e la cottura della zuppa (giorno 2)."
+    "instructionsText": "Questa ricetta si prepara in due fasi: la preparazione del dashi (giorno 1) e la cottura della zuppa (giorno 2).",
+    "videoIds": []
   }
 };

--- a/src/data/recipe-data.ts
+++ b/src/data/recipe-data.ts
@@ -12,6 +12,7 @@ export interface RecipeData {
   recipeIngredient: string[];
   instructionsText: string;
   videoIds: string[];
+  datePublished: string | null;
 }
 
 export const RECIPE_DATA: Record<string, RecipeData> = {
@@ -41,7 +42,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo preparando i funghi enoki. È importante rimuovere la base (la parte terrosa), ma fate attenzione a non tagliare troppo in alto: i funghi devono rimanere uniti alla base per facilitare la frittura e mantenere la forma a ventaglio. Una volta puliti, dividete il mazzo in circa 8 piccoli mazzetti. Prendete un sacchetto per alimenti in plastica (tipo quelli per il gelo) e inserite i mazzetti di enoki insieme alla salsa di soia (o yakiniku), alla maionese, allo zenzero e all'aglio. Chiudete il sacchetto e massaggiate delicatamente affinché la marinatura penetri bene tra le fibre dei funghi. Lasciate riposare per circa 10 minuti in modo che i sapori vengano assorbiti. Passato il tempo di marinatura, scolate i funghi dal liquido in eccesso e trasferiteli in un nuovo sacchetto pulito. Aggiungete i semi di sesamo e la fecola di patate. Il segreto per una panatura perfetta è aggiungere la fecola un cucchiaio alla volta, scuotendo bene il sacchetto per distribuirla uniformemente su ogni mazzetto. In una padella antiaderente, scaldate una piccola quantità di olio di semi a fuoco medio. Quando l'olio è ben caldo, adagiate i mazzetti di enoki ben distanziati tra loro. Friggete finché non raggiungono un bel colore dorato e una consistenza croccante su entrambi i lati.",
     "videoIds": [
       "uK4SKPruJSI"
-    ]
+    ],
+    "datePublished": "2026-02-07T20:14:52+01:00"
   },
   "ricette/agemono/kara-age": {
     "docId": "ricette/agemono/kara-age",
@@ -69,7 +71,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Tagliare il pollo in cubetti di circa 4 centimetri di lato, l'importante è che siano tutti più o meno delle stesse dimensioni, così che si cuociano uniformemente, meglio pezzi un po' piu cicciottelli che restano piu' umidi e danno piu' gusto. Preparare la marinatura, unendo mirin, sake, salsa di soia, e zenzero e aglio grattugiati (o spremuti brutalmente con uno schiaccia aglio). Mettere tutto in una ciotola, coprire con la pellicola e lasciar marinare in frigo per minimo 2 ore, anche se 24 ore e' l'ideale. Dopo la marinatura, infarinare il pollo nella fecola di patate, senza lasciare zone scoperte. Cercare di rimuovere tutta la farina in eccesso, facendo una infarinatura uniforme e leggera. Scaldare l’olio a 160 gradi e friggere una volta (4-5 pezzetti di pollo alla volta, in modo che non si attacchino tra di loro) per circa 90-120 secondi a seconda delle dimensioni del pollo. Lasciare scolare e riposare il pollo per qualche minuto, poi friggere nuovamente, questa volta a 180 gradi per circa 45 secondi - 1 minuto. Di nuovo far asciugare su una griglia, e gustare con la salsa (io uso Maionese Kewpie condita con lo shichimi togarashi). In alternativa, come facciamo anche noi con i fritti, potete gustarlo con una fettina di limone spremuta.",
     "videoIds": [
       "7VbEkKBAs-g"
-    ]
+    ],
+    "datePublished": "2021-08-12T12:23:31+02:00"
   },
   "ricette/antipasti/chawanmushi": {
     "docId": "ricette/antipasti/chawanmushi",
@@ -95,7 +98,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Unire in una ciotola le uova, con il dashi, il mirin, la salsa di soia (se si vuole, il sake) e il sale. Mescolare bene con luna frusta, cercando di non incorporare aria. Setacciare il composto con un colino a maglie strette in un'altra ciotola, e versare il composto nelle ciotoline di ceramica. Mettere nelle ciotoline uno o due gamberi, un paio di ginnan, e un fungo shiitake fatto a fettine. Versare il composto nelle ciotoline, e coprire con un foglio di alluminio. Mettere le ciotoline nella pentola per il vapore, e cuocere a circa 90 gradi per 10 minuti. La cosa piu' semplice per mantenere la temperatura é mettere una bacchetta tra il coperchio e la pentola, per tenere il coperchio socchiuso. Tenere la fiamma appena sufficiente a far sobbollire l'acqua. A questo punto si possono aggiungere altre decorazioni, come l'edamame, o un gambero o delle capesante fatte a fettine, e cuocere per altri 2 minuti. Altrimenti, si puo' cuocere per 12-13 minuti senza aggiungere nulla. Spegnere il fuoco, e lasciare riposare per 7-8 minuti. A questo punto aggiungere un po' di prezzemolo o cipolline, e servire caldo. Alternativamente, si puo' mettere in frigorifero e gustare freddo, con del buon vino bianco o del sake.",
     "videoIds": [
       "koIokEwbbMQ"
-    ]
+    ],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/antipasti/hiyashi_nasu": {
     "docId": "ricette/antipasti/hiyashi_nasu",
@@ -114,7 +118,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Katsuobushi"
     ],
     "instructionsText": "Sbucciare completamente la melanzana con un pelapatate. Avvolgerla poi molto stretta in un foglio di carta da cucina. Passare la melanzana avvolta sotto l'acqua corrente, bagnando uniformemente la carta. Strizzarla bene per eliminare l'acqua in eccesso. Avvolgere nuovamente il tutto, ben stretto, con della pellicola per alimenti adatta al microonde. Cuocere la melanzana nel microonde per 3 minuti alla massima potenza. Questo metodo è una scorciatoia per la classica cottura al vapore. Appena finita la cottura, scartare immediatamente la melanzana dalla pellicola e dalla carta. Lasciarla raffreddare prima a temperatura ambiente, poi metterla in un contenitore e trasferirla in frigorifero finché non sarà completamente fredda. Prendere la melanzana fredda dal frigo e tagliarla a fette o a tocchetti. Disporla su un piattino. Guarnire con le cipolline affettate finemente, condire con un po' di salsa di soia e completare con una generosa manciata di katsuobushi. Provate assolutamente a rifarlo perché è veramente buono, buono, buono. Itadakimasu!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-08-04T10:18:26+02:00"
   },
   "ricette/antipasti/hiyayakko": {
     "docId": "ricette/antipasti/hiyayakko",
@@ -137,7 +142,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Togli il tofu dalla confezione e scolalo delicatamente. Se ha molta acqua, lascialo riposare qualche minuto su carta da cucina per farlo asciugare leggermente, senza romperlo. Taglialo in 2 o 4 pezzi, oppure lascialo intero se lo servi in una sola porzione, e mettilo in una ciotolina o piattino fondo. Versa sopra la salsa ponzu, quanto basta per condirlo ma senza affogarlo. Guarnisci con una grattugiata di zenzero fresco, katsuobushi a piacere, e cipollina verde affettata.",
     "videoIds": [
       "LkaGIe4oocQ"
-    ]
+    ],
+    "datePublished": "2025-02-15T15:15:08+01:00"
   },
   "ricette/antipasti/nama_harumaki": {
     "docId": "ricette/antipasti/nama_harumaki",
@@ -161,7 +167,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per il ripieno, iniziamo dalla preparazione del pollo. In questa ricetta utilizziamo delle alette, pre-cuocendole per una decina di minuti in friggitrice ad aria a 160 gradi. Una volta cotte, priviamole delle ossa sfilacciando la carne grossolanamente con le mani. Trasferiamo il pollo sfilacciato in una padella ben calda e versiamo la nostra salsa teriyaki, lasciando sfrigolare e caramellare i pezzetti di carne fino a renderli lucidi, appiccicosi e irresistibili. Passiamo alle verdure. Mondiamo la carota e la tagliamo a bastoncini sottili e regolari (hosogiri). Laviamo accuratamente le foglie di mizuna, una senape giapponese dal sapore leggermente pungente; se non riuscite a trovarla, una normalissima insalata riccia andrà benissimo per replicare la croccantezza necessaria. A questo punto prepariamo la postazione per l'assemblaggio. Prendiamo un foglio di carta di riso e lo inumidiamo delicatamente su ambo i lati con dell'acqua per farlo ammorbidire. Lo stendiamo sul tagliere e iniziamo a comporre il nostro involtino: posizioniamo prima un letto di foglie di mizuna, aggiungiamo una generosa e voluttuosa striscia di maionese Kewpie, adagiamo il pollo teriyaki caramellato e completiamo con i bastoncini di carota. Ora arriva il momento di mettere in pratica la memoria muscolare per chiudere l'involtino. Solleviamo il lembo inferiore della carta di riso coprendo il ripieno e stringendo bene con le dita. Ripieghiamo i bordi laterali verso l'interno per sigillare i lati, dopodiché continuiamo ad arrotolare l'involtino su se stesso esercitando una leggera pressione, fino a chiuderlo completamente in un cilindro compatto. I nostri Nama Harumaki sono pronti da tagliare a metà e gustare, tanto belli da vedere quanto buoni da mangiare.",
     "videoIds": [
       "Ls_tcuHzqkQ"
-    ]
+    ],
+    "datePublished": "2026-03-26T20:17:13+01:00"
   },
   "ricette/antipasti/sunomono": {
     "docId": "ricette/antipasti/sunomono",
@@ -186,7 +193,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale fino"
     ],
     "instructionsText": "",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-03T20:09:44+02:00"
   },
   "ricette/antipasti/yamitsuki_kyabesu": {
     "docId": "ricette/antipasti/yamitsuki_kyabesu",
@@ -208,7 +216,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di Brodo vegetale in polvere (in sostituzione del Kombucha in polvere)"
     ],
     "instructionsText": "Prendere un contenitore di plastica con coperchio. Tagliare il cavolo cappuccio a quadratoni grossolani, senza essere troppo precisi, e separare le foglie con le mani. Mettere il cavolo tagliato nel contenitore. Aggiungere direttamente sul cavolo un cucchiaio di olio di sesamo, il brodo granulare, il sale e una generosa manciata di semi di sesamo. Chiudere il contenitore con il suo coperchio. Adesso arriva la parte divertente: shakerare fortissimo per qualche secondo, in modo da distribuire uniformemente il condimento e ammorbidire leggermente il cavolo. Aprire, trasferire in una ciotola e servire subito. È già pronta.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-01T15:36:23+02:00"
   },
   "ricette/fish/sudako_negi_vapore": {
     "docId": "ricette/fish/sudako_negi_vapore",
@@ -228,7 +237,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Pepe nero"
     ],
     "instructionsText": "Metti i moscardini in una ciotola di terracotta (o una ciotola capiente). Aggiungi abbondante sale e massaggiali con cura ed energia. Fallo finché non ti sembra di star esagerando: quella è la quantità giusta di frizione. Sciacquali molto bene sotto l'acqua corrente per rimuovere tutto il sale e le impurità. Porta a bollore una pentola d'acqua e aggiungi sale. Immergi i moscardini tenendoli per la testa e bagnando prima solo le punte dei tentacoli ripetutamente (\"choi choi\"). Facendo così, i tentacoli si arricceranno verso l'esterno e prenderanno una bella forma una volta cotti. Quando la testa diventa dura e compatta al tatto, sono pronti. Scolali. Prendi il negi e taglialo diagonalmente a pezzi grossolani. Mettili in un cestello per la cottura al vapore e cuocili finché non diventano teneri e dolci. Nel frattempo prepara la salsa: in un pentolino metti un cucchiaio di zucchero e il doppio della quantità di aceto. Scalda leggermente solo per far sciogliere lo zucchero. Lascia raffreddare e aggiungi una piccolissima quantità di shoyu. Taglia i moscardini bolliti a pezzi facili da mangiare (la tecnica di taglio dipende dai gusti). Impiattamento: disponi il negi cotto al vapore sul fondo del piatto, spargi sopra i pezzi di moscardino. Condisci versando la salsa agrodolce (amazu) e completa con una spolverata di pepe nero. Itadakimasu!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-12-14T11:29:36+01:00"
   },
   "ricette/fish/teriyaki_salmon": {
     "docId": "ricette/fish/teriyaki_salmon",
@@ -250,7 +260,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Salsa Teriyaki"
     ],
     "instructionsText": "Condire il salmone con sale e pepe nero appena macinato, poi passarlo leggermente nella farina bianca. Scaldare l'olio da cucina o il burro in una padella e cuocere il salmone per 3 minuti da un lato fino a doratura. Girare il salmone, aggiungere 1 cucchiaio di sake e coprire la padella per cuocere per altri 3 minuti. Rimuovere il coperchio, versare la salsa Teriyaki e cospargere il salmone con la salsa per ricoprirlo uniformemente.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/menrui/bukkake_udon": {
     "docId": "ricette/menrui/bukkake_udon",
@@ -274,7 +285,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Acqua e ghiaccio"
     ],
     "instructionsText": "I Condimenti: Per prima cosa prepariamo i topping. Prendiamo il nostro Daikon, lo spelliamo e lo grattugiamo. Strizziamolo leggermente per fargli perdere l'acqua in eccesso e teniamolo da parte. Già che ci siamo, andiamo ad affettare finemente anche qualche cipollina. Lo Zenzero: Dopodiché, peliamo un po' di zenzero con il metodo del cucchiaio (che è infallibile), lo grattugiamo e lo mettiamo da parte. Il Brodo (la parte \"Bukkake\"): \"Sì, ma in tutto questo bukkake che c'entra?\" direte voi. Tranquilli, ci arriveremo. In una ciotola mescoliamo il Dashi, un cucchiaio di Mentsuyu e un paio di cucchiaini di salsa di soia. Cottura degli Udon: Nel frattempo, mettiamo a bollire un pentolino d'acqua e, quando bolle, plop, ci mettiamo dentro i nostri udon preconfezionati. Basterà un paio di minuti di cottura. Raffreddamento: Appena cotti, li scoliamo e li facciamo raffreddare direttamente in una ciotola con acqua e ghiaccio. Poi, mi raccomando, scolateli molto bene.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-03T20:09:44+02:00"
   },
   "ricette/menrui/hiyashi_tori_dashi_somen": {
     "docId": "ricette/menrui/hiyashi_tori_dashi_somen",
@@ -291,7 +303,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Sbollentare la sovraccoscia di pollo in acqua bollente per un minuto, quindi scolarla e gettare l'acqua. Questo passaggio serve a pulire il pollo e a garantire un brodo più limpido. In una pentola, unire l'alga kombu, il pollo sbollentato, l'acqua, il sakè, la salsa di soia, il mirin e lo zucchero. Portare a leggero bollore. Cuocere a fuoco basso per 25 minuti, schiumando di tanto in tanto le impurità che affiorano in superficie. A metà cottura, dopo circa 12 minuti, girare il pollo. Al termine della cottura, togliere il pollo e l'alga kombu dalla pentola. Lasciare raffreddare il pollo e il brodo separatamente, poi trasferire il brodo in frigorifero per farlo diventare ben freddo. Preparare i condimenti: tagliare il pollo cotto a fettine sottili e condirlo con un pizzico di sale. Tritare finemente il myoga e le foglie di shiso. Cuocere i somen seguendo le istruzioni sulla confezione. Scolarli e passarli immediatamente in una ciotola con acqua fredda e ghiaccio per bloccare la cottura e renderli più sodi. Scolarli di nuovo molto bene. Prendere il brodo freddo dal frigorifero, aggiungere l'aceto e mescolare. Mettere i somen in una ciotola, versarvi sopra il brodo freddo e guarnire con il trito di myoga e shiso, le fettine di pollo e i germogli di ravanello.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/menrui/natto_soba": {
     "docId": "ricette/menrui/natto_soba",
@@ -317,7 +330,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 uovo fresco che si possa mangiare crudo (opzionale)"
     ],
     "instructionsText": "Bolli i soba in abbondante acqua (io non metto sale), sciacquali sotto l'acqua fredda, trasferiscili in una ciotola con acqua e ghiaccio per raffreddarli, scolali e asciugali bene, e mettili in una ciotola facendo una fossetta al centro, dove metterai il rosso dell'uovo. Aggiungi ai lati il natto, le cipolline tagliate sottili, il katsuobushi, il kizami nori, e il rosso dell'uovo al centro. Opzionale, come in foto, puoi aggiungere un paio di foglie di shiso fresco per guarnire. Mischia il mentsuyu e il dashi, per ottenere lo tsuyu, che verserai al lato della ciotola, per fare un fondo di circa 1 cm di altezza. E ora non ti resta che mangiare! Itadakimasu!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-07-19T10:04:20+02:00"
   },
   "ricette/menrui/tori_dashi_no_nyumen": {
     "docId": "ricette/menrui/tori_dashi_no_nyumen",
@@ -341,7 +355,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Il segreto di questo piatto risiede nella pulizia accurata della materia prima. Iniziamo mettendo le ossa di pollo, preferibilmente spezzate per rilasciare più sapore, in una pentola con un litro e mezzo d'acqua. Portiamo a bollore e lasciamo cuocere per pochi minuti finché non affiorano tutte le impurità in superficie; a questo punto gettiamo l'acqua e sciacquiamo bene le ossa sotto acqua corrente. Rimettiamo le ossa pulite nella pentola con il restante litro e mezzo d'acqua fresca, aggiungendo lo zenzero, lo scarto del porro, la salsa di soia, un pizzico di sale e lo zucchero. Copriamo e lasciamo sobbollire a fiamma bassa per circa un'ora, filtrando poi il brodo ottenuto con un colino a maglie fini per renderlo limpido. Mentre il brodo riposa, cuociamo i somen in acqua bollente per circa 3 minuti. Una volta pronti, è fondamentale scolarli e sciacquarli immediatamente sotto acqua corrente fredda, strofinandoli per rimuovere l'amido, e concludere con un breve bagno in acqua e ghiaccio per fermare la cottura. Per servire, disponiamo i somen in una ciotola, versiamo il brodo di pollo bollente e completiamo con il cipollotto tritato finemente.",
     "videoIds": [
       "aQ8tXgcNsLM"
-    ]
+    ],
+    "datePublished": "2026-02-28T17:25:02+01:00"
   },
   "ricette/menrui/tororo_natto_shiso_udon": {
     "docId": "ricette/menrui/tororo_natto_shiso_udon",
@@ -369,7 +384,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Partiamo dal natto: è sempre un'ottima abitudine tenerne una scorta nel freezer. Quando lo prelevate, togliete la pellicola protettiva mentre è ancora congelato per evitare disastri appiccicosi, dopodiché scongelatelo rapidamente utilizzando il microonde. Una volta rinvenuto, conditelo con la sua salsina e la senape fornite nella confezione, e mescolatelo energicamente con le bacchette; più lo girate, più diventerà filante e \"sbavoso\", proprio come deve essere. Mentre l'acqua per la pasta arriva a bollore, occupiamoci del resto dei condimenti. Tritiamo finemente un po' di cipollotto verde e tagliamo a listarelle sottili le profumate foglie di shiso. A questo punto prendiamo il nostro yamaimo e lo sgrattugiamo vigorosamente fino a trasformarlo in tororo: una crema bianca, morbida, \"fluffosa\" e leggermente gelatinosa. Immergiamo gli udon nell'acqua bollente per un paio di minuti, giusto il tempo necessario affinché i noodles si separino e si ammorbidiscano. Li scoliamo e li laviamo accuratamente sotto l'acqua corrente, tuffandoli immediatamente in una ciotola di acqua e ghiaccio. Questo shock termico è vitale per fermare la cottura e ottenere una consistenza soda, elastica e perfettamente ghiacciata. Diamo un'ultima scolata rigorosa per non annacquare il piatto. È arrivato il momento dell'assemblaggio, la parte più divertente. In una bella ciotola capiente, posizioniamo gli udon ghiacciati sul fondo. Copriamo i noodles con una generosa cascata di tororo cremoso, adagiamo il natto filante al centro e circondiamo il tutto con lo shiso tritato. Facciamo cadere qualche goccia di salsa di soia di ottima qualità per dare la giusta sapidità, e concludiamo l'opera con il cipollotto.",
     "videoIds": [
       "fI0etHpnak8"
-    ]
+    ],
+    "datePublished": "2026-05-05T14:02:10+02:00"
   },
   "ricette/menrui/udon_burro_e_shoyu": {
     "docId": "ricette/menrui/udon_burro_e_shoyu",
@@ -392,7 +408,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Kizami Nori (alga nori a striscioline) per guarnire"
     ],
     "instructionsText": "Cuocere gli udon in abbondante acqua bollente per circa due minuti, o seguendo le istruzioni riportate sulla confezione. Scolare gli udon e trasferirli direttamente in una padella calda. Aggiungere subito la noce di burro e il cucchiaio di salsa di soia. Mantecare a fuoco vivo per circa un minuto, saltando gli udon come si farebbe con la pasta, finché il condimento non si sarà amalgamato creando una salsa cremosa. Impiattare immediatamente. Cospargere con abbondante katsuobushi (usandolo proprio come se fosse parmigiano) e guarnire con una manciata di kizami nori. È una soddisfazione unica, con un rapporto bontà-fatica imbattibile. Itadakimasu!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-01T14:54:45+02:00"
   },
   "ricette/menrui/yaki_udon": {
     "docId": "ricette/menrui/yaki_udon",
@@ -423,7 +440,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo la preparazione tagliando le verdure che formeranno la base del piatto. Tagliamo la carota a listarelle sottili e il cavolo cappuccio a pezzi grossolani. Un trucco importante riguarda la cipolla: va tagliata rigorosamente per il lungo; in questo modo manterrà la sua struttura e non si sfalderà durante la cottura. Tagliamo anche la fettina di carne di maiale a piccoli quadrotti. A parte, prepariamo una salsa mescolando in una ciotolina la salsa di soia, il mirin e il dashi in polvere. Questa e' una versione super semplificata della classica salsa per yakisoba, ma è perfetta per esaltare il sapore degli udon senza sovrastarli. Se volete fare la salda per yakisoba, trovate la ricetta completa qui. Scaldiamo bene una padella capiente (o un wok) con un cucchiaino di olio di semi e iniziamo rosolando i pezzetti di maiale. Una volta che la carne si e' dorata, inseriamo la cipolla, seguita dal cavolo cappuccio e dalle carote, saltando il tutto a fiamma vivace per farle ammorbidire ma preservandone la croccantezza. A questo punto, tuffiamo in padella i nostri udon e versiamo la salsa preparata precedentemente. Diamo una bella mescolata vigorosa saltando la pasta per distribuire i sapori in modo uniforme. Trasferiamo i nostri Yaki Udon ancora fumanti su un piatto da portata e arricchiamo il tutto con l'immancabile katsuobushi, che danzerà con il calore, e un tocco di beni shoga, lo zenzero rosso che aggiunge il perfetto contrasto acido. In soli 10 minuti e con pochissimi ingredienti, avrete portato in tavola l'autentico sapore del Giappone.",
     "videoIds": [
       "7CIiq2RuUtc"
-    ]
+    ],
+    "datePublished": "2026-04-19T19:34:56+02:00"
   },
   "ricette/menrui/yakisoba": {
     "docId": "ricette/menrui/yakisoba",
@@ -449,7 +467,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Katsuobushi"
     ],
     "instructionsText": "Preparare la pasta qualche ora prima, facendola super al dente (gli date giusto una sbollentata), scolate e sciaquatela bene sotto l'acqua fredda, scolatela di nuovo e conditela con un filo d'olio per evitare che si attacchi. Lasciatela a temperatura ambiente fino al momento di usarla. Potete metterla in un sacchetto di plastica ben chiuso, in modo che non si secchi, o in un contenitore ermetico. Taglia la cipolla a fette sottili, il cavolo cappuccio a quadratini, i funghi shiitake a fettine e la pancetta a striscioline. In una padella capiente o wok, scalda un po' d'olio e metti la panctta a rosolare. Quando inizia a rilasciare il grasso, aggiungi la cipolla, cuocendo fino a quando diventa trasparente. Aggiungi il cavolo cappuccio e i funghi shiitake, cuocendo fino a quando il cavolo inizia ad appassire. Aggiungi la pasta e mescola bene per amalgamare gli ingredienti. Versa la salsa yakisoba, dai una bella mescolata e cuoci per qualche minuto senza mescolare, in modo che la pasta faccia tutta una crosticina croccante. All'ultimo aggiungi il benishoga, mescola e servi con una spolverata di aonori e katsuobushi.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/menrui/zaru_soba": {
     "docId": "ricette/menrui/zaru_soba",
@@ -467,7 +486,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "200g di spaghetti di grano saraceno"
     ],
     "instructionsText": "Bollire gli spaghetti in abbondante acqua senza sale per la durata suggerita sulla confezione. Scolarli conservando una tazza dell'acqua di cottura (sobayu). Usare un colino e sciacquarli sotto acqua corrente fredda con le mani per eliminare l'amido in eccesso. Trasferirli in una ciotola con acqua e ghiaccio per raffreddarli per circa 30 secondi, poi scolarli bene e metterli da parte.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-03-10T17:50:10+01:00"
   },
   "ricette/nimono/daikon_no_nimono": {
     "docId": "ricette/nimono/daikon_no_nimono",
@@ -488,7 +508,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per iniziare, prendete un grosso daikon e privatelo delle estremità. Anche se la buccia può sembrare sottile, lo strato esterno è in realtà piuttosto coriaceo, quindi è fondamentale rimuoverlo interamente utilizzando la tecnica del katsuramuki, effettuando un taglio rotatorio con il coltello. Una volta pelato, tagliate il tubero in fette spesse circa 3-4 cm. Per evitare che le fette si sfaldino durante la lunga cottura, rifilate accuratamente gli spigoli di ogni disco seguendo la tecnica del mentori. Per favorire la penetrazione del calore e degli aromi, incidete una croce profonda un paio di centimetri su una delle basi di ogni fetta di daikon. Passate quindi alla fase di pre-cottura: mettete il daikon in una pentola e copritelo con l'acqua recuperata dal lavaggio del riso. Coprite con un otoshibuta e fate bollire per circa un'ora; l'amido contenuto nell'acqua del riso aiuterà a rimuovere l'amaro naturale della radice, rendendola dolcissima. Verificate la cottura con uno stuzzicandente: quando penetra la polpa senza resistenza, scolate il daikon e lavatelo delicatamente sotto acqua corrente. Rimettetelo sul fuoco coprendolo con acqua fresca, portate a bollore e sciacquatelo nuovamente. Questa doppia pulizia assicura un sapore pulito e delicato. Per la cottura finale, disponete le fette in una pentola e ricopritele interamente con del dashi. Aggiungete un cucchiaio di mirin e un paio di cucchiai di salsa di soia (shoyu). Posizionate nuovamente l'otoshibuta e lasciate sobbollire a fuoco dolce per circa mezz'ora. Al termine, spegnete la fiamma e lasciate riposare il daikon nel suo brodo fino a quando non si sarà raffreddato; questo passaggio è fondamentale affinché la radice assorba tutto l'umami del liquido. Mentre il daikon riposa, preparate il guarnimento affettando molto finemente della scorza di limone, avendo cura di prelevare solo la parte gialla. Potete servire il piatto sia freddo che caldo, accompagnandolo con il suo brodo di cottura e completando con le striscioline di limone. Se eseguito correttamente, il daikon risulterà così tenero da poter essere tagliato facilmente con le bacchette.",
     "videoIds": [
       "W1llNvmnKHY"
-    ]
+    ],
+    "datePublished": "2026-05-01T12:12:00+02:00"
   },
   "ricette/nimono/kabocha_no_nimono": {
     "docId": "ricette/nimono/kabocha_no_nimono",
@@ -513,7 +534,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per questa ricetta l'ideale è utilizzare la zucca Mantovana, che è un sostituto perfetto per le zucche giapponesi, ed è facilmente reperibile. Iniziamo tagliando la zucca a pezzetti più o meno uguali, cercando di mantenere la buccia che in cottura diventerà tenera ed aiuterà i pezzi a non sfaldarsi. Prendiamo una pentola e disponiamo i pezzi di zucca sul fondo creando un vero e proprio mosaico, con la buccia preferibilmente rivolta verso l'alto o il basso in modo ordinato, cercando di non sovrapporli troppo. Copriamo il tutto con il dashi (usando il dashi vegano per mantenere la ricetta 100% vegetale) fino a coprire appena la zucca, e accendiamo il fuoco. Appena il liquido raggiunge il bollore, abbassiamo la fiamma al minimo e procediamo con il condimento. Aggiungiamo un paio di cucchiai di salsa di soia, un paio di mirin e un paio di sake, regolando le quantità in base a quanta zucca state cucinando. Se volete un sapore più dolce e glassato, potete aggiungere anche un cucchiaio di zucchero in questa fase. A questo punto copriamo con un otoshibuta, il tipico coperchio più piccolo della pentola che poggia direttamente sugli alimenti. Questo strumento è fondamentale nei nimono perché permette di usare meno brodo, diffonde il calore uniformemente e tiene fermi gli ingredienti evitando che si rompano col bollore. Se non lo avete, potete realizzarlo facilmente con un foglio di carta forno ritagliato a misura e bucato al centro. Lasciamo stufare per circa 10 minuti. Per verificare la cottura, facciamo la prova con uno stuzzicadenti: se entra facilmente nella polpa, la zucca è pronta.",
     "videoIds": [
       "usKM2qSpBQs"
-    ]
+    ],
+    "datePublished": "2026-01-21T15:13:46+01:00"
   },
   "ricette/nimono/kakuni": {
     "docId": "ricette/nimono/kakuni",
@@ -541,7 +563,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "4 uova"
     ],
     "instructionsText": "Prima di tutto una premessa: questo è il metodo \"veloce\" per la preparazione del buta kaku-ni. Secondo il metodo tradizionale, spiegato ottimamente da Shizuo Tsuji nel suo libro \"Japanese Cooking: A Simple Art\" (praticamente la bibbia della cucina giapponese), ci vogliono due giorni per preparare il kakuni. Giuro che un giorno ci proverò, ma per ora mi accontento di questa versione. Tagliare la pancetta in pezzi di 5 cm di lato, e rosolare i cubi in una padella antiederente, 2 minuti per lato (12 minuti in totale). Asciugarli con un panno o dei fazzoletti di carta per eliminare il grasso in eccesso. Mettere i cubi di pancetta rosolata in una pentola a pressione, con il lato della pelle rivolto verso il basso. Aggiungere acqua tiepida ed un bicchiere di sake, fino a coprire la pancetta. Aggiungere la parte verde della cipolla e lo zenzero tagliato a fette. Chiudere la pentola a pressione e cuocere per mezz'ora. Scolare la pancetta e metterla da parte. Filtrare il brodo di cottura, facendolo freddare per poi togliere il grasso. Cuocere le uova in acqua bollente per 6 minuti e 30 secondi (prendendole dal frigo così partono sempre dalla stessa temperatura), in modo che restino liquide al centro, raffreddarle in acqua ghiacciata e sbucciarle. Sbollentare il bok choi in acqua bollente per 1 minuto, o saltarlo in padella con aglio e zenzero, e metterlo da parte. In una casseruola, mettere il brodo, la salsa di soia, il mirin, lo zucchero e il sake. Aggiungere la pancetta e il daikon tagliato a fette, e cuocere a fuoco basso facendo sobbollire per per 30 minuti. Negli ultimi 10 minuti aggiungere le uova e togliere il coperchio in modo che si ritiri un po' la salsa. Servire il kakuni con il bok choy e il daikon, e un po' di salsa. Guarnire a piacere con senape karashi, shichimi togarashi, e la parte bianca della cipolla verde tagliata a julienne e immersa in acqua fredda per arricciarla.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-06-27T13:47:56+02:00"
   },
   "ricette/nimono/nikujaga": {
     "docId": "ricette/nimono/nikujaga",
@@ -567,7 +590,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "La preparazione inizia con il taglio delle verdure, che in questo piatto deve essere piuttosto rustico ma curato. Tagliamo la carota e la cipolla a pezzettoni grossolani. La carne di manzo deve essere tagliata a straccetti o fettine sottili, ideali per una cottura in umido veloce che la mantenga morbida. Passiamo alle patate: dopo averle tagliate a pezzi grandi, è fondamentale eseguire il mentori. Con un pelapatate, rifiliamo tutti gli spigoli vivi di ogni pezzo di patata, smussandoli. Questa tecnica serve a evitare che la patata si sfaldi e si rompa durante la cottura nel liquido, mantenendo il brodo limpido e i pezzi integri. Per la cottura, l'ordine di inserimento degli ingredienti è importante. Scaldiamo un filo di olio di semi in una pentola capiente (o un tegame di ghisa) e inseriamo prima le patate, poi le cipolle. Rosoliamo le verdure insieme per qualche minuto per insaporirle. Solo a questo punto aggiungiamo la carne. Non cerchiamo una rosolatura aggressiva della carne, ma vogliamo cuocerla dolcemente affinché si sfaldi e diventi tenerissima in cottura. Una volta che la carne ha cambiato colore, uniamo le carote e copriamo tutto a filo con il dashi. Alziamo la fiamma al massimo e portiamo a bollore. Appena il liquido bolle, utilizziamo un colino a maglia fine per \"schiumare\" il brodo, rimuovendo tutte le impurità che affiorano in superficie. A questo punto condiamo aggiungendo un giro di mirin e di salsa di soia. Abbassiamo la fiamma al minimo e copriamo con un otoshibuta. Lasciamo cuocere dolcemente per circa 15 minuti. Trascorso questo tempo, spegniamo il fuoco e lasciamo riposare: è in questa fase che i sapori si amalgamano e le verdure assorbono il condimento. Mentre il Nikujaga riposa, possiamo sbollentare brevemente delle taccole in acqua salata: useremo il loro verde brillante come guarnizione decorativa per dare un tocco di colore al piatto finito.",
     "videoIds": [
       "yNDVtIMAxtY"
-    ]
+    ],
+    "datePublished": "2026-01-21T15:12:45+01:00"
   },
   "ricette/preparazioni_di_base/brodi/dashi": {
     "docId": "ricette/preparazioni_di_base/brodi/dashi",
@@ -589,7 +613,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "videoIds": [
       "SQjoBpeNOhg",
       "JzrHdn_lr-I"
-    ]
+    ],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/preparazioni_di_base/brodi/mentsuyu": {
     "docId": "ricette/preparazioni_di_base/brodi/mentsuyu",
@@ -614,7 +639,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Metti tutto in un pentolino e porta molto dolcemente a ebollizione, poi spegni il fuoco e lascia freddare Filtra tutto e metti in un barattolo, la salsa inizia a dare il meglio di se dopo 2-3 giorni in frigorifero. Non so ancora quanto si conservi a lungo, ne ho una di 2 mesi, sembra buona e non sono ancora morto.",
     "videoIds": [
       "gXeX1rC_YTs"
-    ]
+    ],
+    "datePublished": "2021-07-07T13:43:12+02:00"
   },
   "ricette/preparazioni_di_base/brodi/vegan_dashi": {
     "docId": "ricette/preparazioni_di_base/brodi/vegan_dashi",
@@ -635,7 +661,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "5 Funghi Shiitake disidratati (secchi)"
     ],
     "instructionsText": "La preparazione richiede tempo e pazienza per estrarre al meglio i sapori in modo delicato (infusione a freddo).",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-05T10:46:48+02:00"
   },
   "ricette/preparazioni_di_base/condimenti/furikake": {
     "docId": "ricette/preparazioni_di_base/condimenti/furikake",
@@ -657,7 +684,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Alga nori"
     ],
     "instructionsText": "Se il Katsuobushi e' nuovo, prendetene una bella manciata e tostatelo in padella, come si fa col sesamo (ovvero a fuoco medio, senza coperchio, muovendolo spesso e togliendolo quando inizia a imbrunire) Se invece e' usato, strizzatelo benissimo, e cercate di sfilacciarlo il piu' possibile prima di metterlo in padella. Poi mettetelo in una padella bella ampia, in modo che non tenda ad appallottolarsi, e fare come sopra, ma con molto piu' tempo ed attenzione. Quando il Katsuobushi e' bello tostato, sbriciolatelo senza pieta' (si ma fate pezzetti, non sabbia...) L'alga kombu, se e' nuova ed essiccata, mettetela a bagno un po' per ammorbidirla, senno' finisce che ci rompete il coltello. E poi, nuova o usata che sia, fatela a quadratini di mezzo centimetro di lato. Tostate i semi di sesamo (come se fosse Katsuobushi), senza distrarvi e a fuoco medio-basso, perche' come vi distraete si carbonizzano immediatamente. Sbriciolate l'alga nori con le mani, da molta soddisfazione. Anche qui attenti a non fare l'Aonori per sbaglio. Comunque, siccome la kombu, cosi come e', e' dura da morire, mettetela in una padella, e metteteci tutto il condimento. Fate andare a fuoco basso, finche' il liquido non si sara' ritirato, e l'alga kombu ammorbidita. Se l'alga kombu e' ancora dura, aggiungete un po' di acqua e fate andare ancora. Quando il liquido avra' raggiunto la densita' della salsa Teriyaki quando e' pronta (ho imparato da mia madre a dare sempre istruzioni utilissime), spegnete il fuoco e aggiungete il katsuobushi, i semi di sesamo e l'alga nori, e mescolate bene. Alla fine vengono tutte palline ammappazzate ma non vi preccupate. Mettete tutto in forno su un bel foglio di carta da forno, a bassa temperatura (70-75 gradi), e ogni tanto aprite il forno, mescolate, sfragnate, e richiudete, finche' non sara' tutto bello secco e croccante. A questo punto dategli un'ultima sfragnata e mettete in un barattolo, e ciaone dal Giappone.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2022-01-05T17:58:24+01:00"
   },
   "ricette/preparazioni_di_base/salse/nikiri": {
     "docId": "ricette/preparazioni_di_base/salse/nikiri",
@@ -677,7 +705,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1/2 tazza di dashi"
     ],
     "instructionsText": "Metti il mirin e il sake in un pentolino a scaldare, e fai evaporare tutto l'alcol. Aggiungi la salsa di soia e il dashi, e fai sobbollire a fuoco basso fino a ridurre della metà il volume. Fai raffreddare e metti in frigo.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-07-22T14:49:54+02:00"
   },
   "ricette/preparazioni_di_base/salse/okonomiyaki": {
     "docId": "ricette/preparazioni_di_base/salse/okonomiyaki",
@@ -698,7 +727,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di aceto di mele o aceto di riso (opzionale, se preferisci un tocco acidulo)"
     ],
     "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di ostriche. Aiutati con una piccola frusta per amalgamare bene il composto. Aggiungi lo zucchero (o il miele) e gira finché si scioglie del tutto, dando alla salsa la dolcezza tipica per l’okonomiyaki. Versa la salsa di soia e, se desideri una punta di acidità in più, un cucchiaino di aceto (di mele o di riso). Continua a mescolare finché il tutto non risulta ben omogeneo. Prova la salsa e, se occorre, aggiungi un pizzico di zucchero o qualche goccia di soia in più, per bilanciare dolce, salato e acidulo secondo il tuo gusto.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/preparazioni_di_base/salse/ponzu": {
     "docId": "ricette/preparazioni_di_base/salse/ponzu",
@@ -720,7 +750,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 parte di mirin"
     ],
     "instructionsText": "Mescolare a freddo in una ciotolina, e lasciare riposare in frigo per almeno 30 minuti prima di servire. Si conserva per un sacco di tempo, non sono mai riuscito a farla andare a male!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/preparazioni_di_base/salse/takoyaki": {
     "docId": "ricette/preparazioni_di_base/salse/takoyaki",
@@ -737,7 +768,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "½ cucchiaio di ketchup"
     ],
     "instructionsText": "Mescolare a freddo - e regolare lo zucchero in base alla dolcezza del ketchup",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/preparazioni_di_base/salse/tentsuyu": {
     "docId": "ricette/preparazioni_di_base/salse/tentsuyu",
@@ -757,7 +789,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Daikon grattugiato"
     ],
     "instructionsText": "Versare tutti gli ingredienti in un pentolino, e scaldare fino a sobbollire (se c'e' lo zucchero, controllare che sia completamente dissolto), far freddare e conservare in un barattolo in frigorifero (2-3 settimane max) Quando si serve, mischiare con daikon grattugiato",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-02-15T15:15:08+01:00"
   },
   "ricette/preparazioni_di_base/salse/teriyaki": {
     "docId": "ricette/preparazioni_di_base/salse/teriyaki",
@@ -781,7 +814,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "In un piccolo tegame, riscaldare il sake e il mirin fino al lieve bollore. Utilizzando un accendino con punta lunga, incendiare l'alcool in eccesso. Successivamente, incorporare la salsa di soia e lo zucchero, mescolando a fuoco bassissimo fino a ottenere un leggero sobbollimento. Questo processo conferisce alla salsa di soia una nota più profonda e favorisce una leggera caramellizzazione. È possibile arricchire il sapore aggiungendo la parte verde dei porri, fettine di zenzero o aglio tritato, a seconda delle preferenze o del piatto a cui è destinata. Io continuo la cottura fino a che non si riduce di circa la metà del suo volume, ma potete proseguire fino a raggiungere l'intensità di sapore desiderata. A parte, diluire la fecola di patate in un po' d'acqua fredda, poi versarla nel tegame, mescolando accuratamente, e lasciar sobbollire per altri 5 minuti. La salsa si addensa e diventa liscia e lucida.",
     "videoIds": [
       "zQowDw_-cOo"
-    ]
+    ],
+    "datePublished": "2021-05-23T18:10:27+02:00"
   },
   "ricette/preparazioni_di_base/salse/tonkatsu": {
     "docId": "ricette/preparazioni_di_base/salse/tonkatsu",
@@ -800,7 +834,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di aceto di mele (opzionale, se desideri una nota più acidula)"
     ],
     "instructionsText": "In una ciotolina, unisci ketchup, salsa Worcestershire e salsa di soia. Aggiungi lo zucchero (o il mirin) e mescola con una piccola frusta o un cucchiaio fino a farlo sciogliere completamente. Se preferisci un tocco più delicato, usa il mirin al posto dello zucchero. Incorpora il cucchiaino di senape (karashi o dijon) e, se gradisci una punta di acidità in più, un cucchiaio di aceto di mele. Continua a mescolare finché il composto non risulta omogeneo. Prova la salsa e, se necessario, modifica il bilanciamento dolce-salato-agro, regolando con un pizzico di zucchero o qualche goccia in più di salsa di soia.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/preparazioni_di_base/salse/yakisoba_sauce": {
     "docId": "ricette/preparazioni_di_base/salse/yakisoba_sauce",
@@ -818,7 +853,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "4 cucchiai di Salsa worcestershire"
     ],
     "instructionsText": "In una ciotola, versare per primo lo zucchero. Questo è il passaggio più importante per assicurarsi che si sciolga bene. Aggiungere le salse procedendo dalla più densa alla più liquida per facilitare la miscelazione. Iniziare quindi con il ketchup, seguito dalla salsa di ostriche. Versare infine la salsa di soia e la salsa worcestershire. Mescolare energicamente con un cucchiaio o una piccola frusta finché lo zucchero non sarà completamente disciolto e la salsa non risulterà omogenea. La salsa è pronta per essere usata, ma il giorno dopo sarà ancora meglio, quando i sapori si saranno amalgamati. Si conserva in frigorifero per una settimana circa.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-01T14:55:19+02:00"
   },
   "ricette/preparazioni_di_base/salse/yakitori": {
     "docId": "ricette/preparazioni_di_base/salse/yakitori",
@@ -841,7 +877,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Opzionale - zenzero e aglio grattugiati"
     ],
     "instructionsText": "Bollire al minimo fino a ridurre della metà il volume.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar": {
     "docId": "ricette/preparazioni_di_base/sushi_and_sashimi/sushi_vinegar",
@@ -853,7 +890,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Sciogliere completamente lo zucchero e il sale nell'aceto, aggiungere l'alga e lasciare riposare per 24 ore in frigorifero. Dopo 24 ore, filtrare e imbottigliare, ed e' pronto per l'uso.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2022-07-21T18:30:06+02:00"
   },
   "ricette/riso/gyudon": {
     "docId": "ricette/riso/gyudon",
@@ -882,7 +920,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Taglia la cipolla a fettine sottili per il lungo, e la cipollina verde a rondelle sottili. In una padella mmetti il dashi, la salsa di soia, il mirin e il sake e le cipolle, fai cuocere a fuoco medio fino a che le cipolle non si ammorbidiscono. Usa un coperchio per non far evaporare il brodo. Dopo 2-3 minuti aggiungi la carne e fai cuocere finche' la carne non e' piu' rosa. Quando la carne e' cotta, spegni il fuoco e aggiungi la cipollina verde. Versa il tutto sopra il riso caldo e guarnisci con beni shoga.",
     "videoIds": [
       "KYZHouOLnr4"
-    ]
+    ],
+    "datePublished": "2024-05-01T10:21:45+02:00"
   },
   "ricette/riso/hamburger_don": {
     "docId": "ricette/riso/hamburger_don",
@@ -905,7 +944,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Tritare finemente la cipolla. Scaldare l'olio di semi in una padella a fuoco medio. Aggiungere la cipolla e soffriggere finché non appassisce. Aggiungere la carne macinata mista, condire con sale e pepe. Continuare a cuocere, premendo la carne per rosolarla e sgranarla, finché non è ben cotta. Aggiungere il ketchup e la salsa Worcestershire e saltare per 1-2 minuti finché il liquido in eccesso non evapora. Creare tre incavi nel composto di carne. Rompere un uovo in ciascun incavo. Abbassare la fiamma e cuocere per circa 5 minuti, o finché le uova non raggiungono la cottura desiderata. Mettere il riso caldo nelle ciotole individuali e adagiarvi sopra il composto di carne e uova.",
     "videoIds": [
       "SJweMEALMks"
-    ]
+    ],
+    "datePublished": "2025-10-30T12:42:13+01:00"
   },
   "ricette/riso/nira_shio_kombu_onigiri": {
     "docId": "ricette/riso/nira_shio_kombu_onigiri",
@@ -935,7 +975,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo tritando finemente l'erba aglina (nira) al coltello. In una ciotola capiente, disponiamo il riso cotto, che per questa preparazione deve essere rigorosamente ben caldo. Aggiungiamo in grande abbondanza la nira, il sesamo, un bel giro di olio di sesamo, lo shio kombu e il katsuobushi. Con l'aiuto di una spatola, mischiamo bene tutto il composto. Passiamo ora alla formatura delle nostre magiche polpette di riso giapponesi. È fondamentale avere le mani bagnate e ben salate per evitare che il riso si attacchi e per dare sapidità all'esterno. L'arte dell'onigiri sta nell'appallottolare e \"striangolare\" il composto con delicatezza: non dobbiamo fare una palla appiccicosa, ma dobbiamo assicurarci di mantenerlo arioso e \"fluffoso\" all'interno. Per aiutare gli onigiri a mantenere perfettamente la forma, è consentito e suggerito avvilupparli strettamente nella pellicola da cucina. Li lasciamo riposare così finché non si potranno raffreddare e solidificare a dovere. Il tocco finale è l'alga. Prendiamo un foglio di alga nori e, prestando attenzione, lo passiamo direttamente sopra la fiamma viva del fornello per averla bella croccante. Liberiamo gli onigiri dalla pellicola, li avvolgiamo nella nori appena tostata e la magia è servita.",
     "videoIds": [
       "wEFtXLWRuTQ"
-    ]
+    ],
+    "datePublished": "2026-04-27T08:56:46+02:00"
   },
   "ricette/riso/onigiri": {
     "docId": "ricette/riso/onigiri",
@@ -959,7 +1000,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Sciacqua il riso sotto acqua fredda fino a che l'acqua non risulta limpida. Cuoci il riso con la quantità di acqua indicata, utilizzando una pentola con coperchio o una cuociriso. Una volta cotto, lascia riposare coperto per 10 minuti. Mentre il riso cuoce, prepariamo il ripieno. Scola il tonno molto accuratamente. In una ciotola, mescola il tonno con la maionese fino a ottenere un composto omogeneo e cremoso, ma non eccessivamente liquido. Puoi aggiungere un pizzico di pepe nero o meglio ancora di shichimi togarashi). Tieni una piccola ciotola d'acqua con un pizzico di sale. Bagna le mani con l'acqua salata: questo aiuterà a non far attaccare il riso e a condire l'esterno dell'onigiri. Prendi una porzione di riso cotto, grande piu o meno come una palla da tennis, e appiattiscila nel palmo della mano, creando una conca al centro. Metti un cucchiaio abbondante di ripieno di tonno e maionese nella conca. Copri il ripieno con il riso circostante e sigillalo completamente, poi modella il tutto con entrambe le mani nella classica forma triangolare, premendo delicatamente per compattare. Taglia i fogli di alga nori a strisce (circa 3-4 cm di larghezza). Avvolgi una striscia alla base dell'onigiri, lasciando le estremità rivolte verso l'esterno, per creare un pratico punto in cui afferrare lo snack senza toccare il riso.",
     "videoIds": [
       "okzY1FVMwDg"
-    ]
+    ],
+    "datePublished": "2021-05-23T18:10:27+02:00"
   },
   "ricette/riso/onigiri_kimchi_asiago": {
     "docId": "ricette/riso/onigiri_kimchi_asiago",
@@ -982,7 +1024,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo la preparazione tritando finemente al coltello il kimchi e grattugiando il formaggio Asiago. In una ciotola capiente, uniamo questi due ingredienti al riso. È fondamentale che il riso sia ancora ben caldo, mi raccomando bello fumante, affinché i sapori si amalgamino perfettamente e il formaggio inizi a sciogliersi. Mescoliamo il composto con gran delicatezza: non vogliamo fare un pappone. Passiamo ora alla formatura. Ci bagniamo ben bene le mani con l'acqua per impedire al riso di appiccicarsi e iniziamo a striangolare il composto, compattandolo fino a dargli la classica forma a triangolo. Non preoccupatevi se all'inizio non vengono dei bellissimi onigiri. Un trucco professionale per assicurarci che tengano bene la forma è avvolgere ogni onigiri con della pellicola da cucina e farli riposare per una mezz'oretta, affinché si compattino bene. Trascorso il tempo di riposo, ungiamo una padella con un po' di olio di semi e la scaldiamo a fuoco basso. Adagiamo delicatamente i nostri onigiri e li facciamo croccare a fiamma bassa da tutti i lati, ma proprio tutti. Per completare, come dei veri professionisti, facciamo croccare la nostra alga nori passandola rapidamente a fiamma viva sul fornello. Capirete che è bella secca quando si spezzerà da sola. Aggiungiamo l'alga all'ultimo momento, a mo' di tovagliolino edibile, in maniera che rimanga bella croccante mentre addentiamo il nostro onigiri filante e saporito.",
     "videoIds": [
       "KNOLKWzaFMs"
-    ]
+    ],
+    "datePublished": "2026-04-01T19:49:18+02:00"
   },
   "ricette/riso/oyakodon": {
     "docId": "ricette/riso/oyakodon",
@@ -1010,7 +1053,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "olio di semi di arachide"
     ],
     "instructionsText": "L'Oyakodon va fatto su una padellina monoporzione, perche' poi lo fai scivolare tutto direttamente sulla ciotola di riso (caldo) Taglia la cipolla a fettine secondo la lunghezza della cipolla, il pollo a cubetti, e le cipolline a rondelle o losanghe. Rompi le uova in una ciotolina, e mescolale delicatamente (senza sbatterle) con le bacchette. Marina il pollo nel sake per 20 minuti. Asciuga bene il pollo e fallo rosolare a fuoco basso girandolo una sola volta quando si e' dorato. Quando e' dorato da entrambi i lati, toglierlo dalla padellina e metterlo da parte. Versa il dashi, il mirin e la salsa di soia nel pentolino, accendi il fuoco, aggiungi le cipolle e fai sobollire a fuoco medio-basso per 4 minuti. A questo punto abbassa la fiamma, e aggiungi il pollo. Fai sobollire per altri 2 minuti, fin quando il pollo non e' completamente cotto e il brodo non si e' ristretto un po'. Alza il fuoco a medio, versa delicatamente 2/3 dell'uovo cercando di coprire tutto. Mischia il resto dell'uovo alle cipolline e mettilo da parte. Fai andare 30-40 secondi a fuoco medio, poi abbassa la fiamma e cuoci un altro minuto, il brodo non si deve essere asciugato. Mischia molto delicatamente, e versa il restante uovo con le cipolline. A questo punto, spegni pure la fiamma e fai cuocere con il calore residuo per un altro minuto. La ricetta originale (come piace a me) prevede che l'uovo resti mezzo crudo e bello bavoso. Trasferisci il contenuto del pentolino direttamente sul riso facendocelo scivolare sopra. Servire caldo.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-10-12T12:10:43+02:00"
   },
   "ricette/riso/soborodon": {
     "docId": "ricette/riso/soborodon",
@@ -1043,7 +1087,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo occupandoci delle uova, che andranno a formare la prima metà del nostro colorato mosaico. Rompiamo le uova in una ciotola, sbattiamole leggermente con le bacchette e versiamole in una padella scaldata con un filo d'olio. Dobbiamo strapazzarle in modo continuo e veloce, cercando di creare dei grumi piccoli e soffici, senza seccarle troppo. Una volta pronte, trasferiamole su un piatto e teniamole da parte. Nella stessa padella (non serve lavarla), inseriamo la carne macinata di pollo cruda. Aggiungiamo subito i condimenti: il mirin, il sake, la salsa di soia e lo zenzero fresco grattugiato. Accendiamo il fuoco e iniziamo a cuocere sgranando la carne in continuazione con una spatola di legno. Questo passaggio è fondamentale: la carne deve cuocersi sminuzzandosi il più possibile, assorbendo tutti i liquidi della marinatura. Continuiamo la cottura fino a quando il sughetto sul fondo non si sarà quasi completamente asciugato, lasciando il macinato saporito e ben sgranato. Ora arriva il momento più divertente: l'assemblaggio. Prepariamo una ciotola capiente creando una base soffice di riso bianco. Disponiamo le uova strapazzate su una metà della ciotola e il macinato di pollo sull'altra metà. Per separare queste due \"tifoserie\", creiamo una coreografica linea di demarcazione centrale utilizzando i piselli sbollentati. Infine, per dare un tocco di acidità che pulisce il palato e un accento di colore rosso vivo, adagiamo al centro un ciuffetto di beni shoga. Il vostro Soboro Don è pronto per essere ammirato e, soprattutto, divorato!",
     "videoIds": [
       "K7zTH4QJgds"
-    ]
+    ],
+    "datePublished": "2026-03-20T08:32:38+01:00"
   },
   "ricette/riso/takenoko_gohan": {
     "docId": "ricette/riso/takenoko_gohan",
@@ -1064,7 +1109,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Qualche foglia di Kinome (germogli di pepe sansho) per guarnire (opzionale)"
     ],
     "instructionsText": "",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2026-01-01T16:54:52+01:00"
   },
   "ricette/riso/takenoko_to_aburaage_takikomi_gohan": {
     "docId": "ricette/riso/takenoko_to_aburaage_takikomi_gohan",
@@ -1094,7 +1140,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per prima cosa ci occupiamo del tofu fritto, che necessita di un passaggio specifico: va lavato abbondantemente con acqua bollente, poi va strizzato con le mani e ben asciugato con della carta assorbente per fargli perdere tutto l'olio in eccesso. Una volta sgrassato, lo tagliamo a fettine sottili. Procediamo tagliando a fette anche il germoglio di bambù e immergiamo la parte verde del cipollotto tagliata a rondelle in una ciotola con acqua e ghiaccio. Passiamo alla preparazione del riso: utilizziamo un misurino preciso di varietà originario e lo laviamo più volte, scolandolo e massaggiandolo sotto l'acqua, finché l'acqua di risciacquo non diventerà completamente trasparente. Quando siamo soddisfatti del risultato, scoliamo bene il riso. Nello stesso misurino del riso uniamo la salsa di soia, il mirin, il sake e il dashi in polvere. A questa miscela di sapori aggiungiamo dell'acqua fresca fino a raggiungere lo stesso esatto volume del riso utilizzato in partenza. Se vogliamo fare più porzioni, basta moltiplicare tutto per il numero di misurini di riso che vogliamo cuocere. A questo punto componiamo il piatto direttamente nel cestello del cuociriso: inseriamo sul fondo il riso pulito, versiamo tutto il liquido e disponiamo sulla superficie i pezzetti di bambù e tofu fritto. Avviamo la cottura e lasciamo compiere la magia. Una volta terminata la cottura, apriamo il coperchio e diamo una bella mescolata al riso, portando in superficie la crosticina che si sarà formata sul fondo. Non ci resta che impiattare in una ciotola, guarnire con le magiche cipolline scolate dall'acqua e ghiaccio, e gustare.",
     "videoIds": [
       "2_bqX5GQij0"
-    ]
+    ],
+    "datePublished": "2026-04-14T15:33:39+02:00"
   },
   "ricette/riso/takikomi_gohan": {
     "docId": "ricette/riso/takikomi_gohan",
@@ -1119,7 +1166,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "pollo/tonno in scatola/varie ed eventuali"
     ],
     "instructionsText": "Quando lavi il riso poi lascialo a bagno una mezz’ora e poi un quarto d’ora ad asciugare: assorbira’ meglio il condimento Metti gli shiitake a mollo nel dashi tiepido, dopo mezz’ora filtra il tutto, otterrai lo shiitake dashi. Nella risiera metti il riso, il sale (non te lo scordare, molto poco ma ci vuole) la soia e il mirin, lo shiitake dashi (deve essere della stessa quantita’ in volume del riso) e mischia bene, fai depositare il riso e poi sopra metti, a strati, gli ingredienti, dal più duro al piu’ morbido. Accendi la risiera e non toccare, gira solo quando ha finito, e vedrai che ti mangi.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-12-09T14:08:28+01:00"
   },
   "ricette/sides/bieta_gialla_ohitashi": {
     "docId": "ricette/sides/bieta_gialla_ohitashi",
@@ -1139,7 +1187,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per prima cosa, portiamo a bollore abbondante acqua e la saliamo generosamente. La bieta ha consistenze diverse tra gambo e foglia, quindi richiede una cottura scaglionata. Immergiamo prima i gambi nell'acqua bollente tenendo le foglie fuori, calcolando circa 30-40 secondi. Trascorso questo tempo, spingiamo sotto anche tutta la parte fogliare e proseguiamo la cottura per altri 30 secondi. La verdura deve rimanere croccante e \"al dente\". Scoliamo la bieta e la tuffiamo immediatamente in una ciotola piena di acqua e ghiaccio. Questo passaggio fondamentale serve a fermare la cottura e a far raffreddare benissimo le foglie, fissando un colore verde brillante (e un giallo acceso per i gambi). Una volta fredda, allineiamo le foglie in modo ordinato e procediamo a strizzarle con molta cura. Partendo dai gambi e scendendo verso le punte, applichiamo un movimento \"strizzatorio\" deciso per eliminare tutta l'acqua in eccesso, che altrimenti annacquerebbe il condimento. Disponiamo la bieta compatta su un tagliere e la tagliamo in porzioni uguali, calcolando la misura in base al contenitore di vetro in cui la faremo riposare. Adagiamo i mazzetti tagliati nel contenitore con delicatezza e ordine. A parte, prepariamo la marinatura unendo il dashi, il mirin e la salsa di soia, assaggiando e correggendo le dosi a seconda del proprio gusto. Versiamo questo liquido sulle verdure in modo da coprirle. Per assicurarci che tutta la bieta resti uniformemente a contatto con il liquido, copriamo la superficie con un panno di carta da cucina, che si inzupperà fungendo da coperchio a contatto. Chiudiamo il contenitore e lasciamo riposare in frigorifero per qualche ora. Al momento di servire, con la pazienza di un giocatore di shangai, preleviamo i mazzetti e li disponiamo in maniera fotogenica in una ciotolina, ricordandoci di versare sopra qualche cucchiaio del loro squisito brodino freddo.",
     "videoIds": [
       "GSGDzrBpbUQ"
-    ]
+    ],
+    "datePublished": "2026-03-15T20:04:18+01:00"
   },
   "ricette/sides/burokkori_no_okaka-ae": {
     "docId": "ricette/sides/burokkori_no_okaka-ae",
@@ -1163,7 +1212,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Iniziamo dividendo i broccoli in cimette di dimensioni omogenee. Per la cottura tradizionale, sbollentiamo i broccoli in acqua per un paio di minuti: l'obiettivo è ammorbidirli leggermente mantenendoli però ben croccanti e tenaci al morso. Il passaggio fondamentale arriva subito dopo la scolatura: i broccoli caldi vanno letteralmente fiondati in una ciotola con acqua e ghiaccio. Questo shock termico serve a fermare immediatamente la cottura, fissare la loro naturale croccantezza e, soprattutto, a preservare quella meravigliosa \"verdosità\" e brillantezza che rende il piatto appagante anche alla vista. Una volta ben freddi, scoliamoli accuratamente e trasferiamoli in una ciotola capiente. Passiamo al condimento: aggiungiamo un cucchiaio di salsa di soia e un cucchiaio di olio di sesamo. Quest'ultimo non fa parte della ricetta canonica e tradizionale, ma regala una spinta aromatica che si sposa divinamente con gli altri sapori. Sgrattugiamo abbondante sesamo tostato direttamente sui broccoli e, infine, aggiungiamo il vero protagonista del piatto: una generosa manciata di katsuobushi. Diamo una bella mescolata per distribuire uniformemente i sapori e serviamo su un bel piatto di portata.",
     "videoIds": [
       "gCil7EuAVMU"
-    ]
+    ],
+    "datePublished": "2026-03-03T08:21:17+01:00"
   },
   "ricette/sides/horenso_no_ohitashi": {
     "docId": "ricette/sides/horenso_no_ohitashi",
@@ -1182,7 +1232,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino colmo di Sale (per la bollitura)"
     ],
     "instructionsText": "",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2026-01-01T20:10:53+01:00"
   },
   "ricette/sides/mugen_oba_nasu": {
     "docId": "ricette/sides/mugen_oba_nasu",
@@ -1201,7 +1252,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di Olio vegetale"
     ],
     "instructionsText": "In una ciotola capiente, unire tutti gli ingredienti per la salsa: salsa di soia, aceto, zucchero, brodo granulare, aglio, zenzero e semi di sesamo. Mescolare bene e mettere da parte. Rimuovere il gambo dalle foglie di shiso e tagliarle a julienne. Tagliare le melanzane: rimuovere il picciolo, dividerle a metà per il lungo e poi tagliare ogni metà in 3 o 4 spicchi a forma di ventaglio. Immergere gli spicchi in acqua per 5-10 minuti per eliminare l'amaro, quindi scolarli e asciugarli molto bene. Mettere le melanzane asciutte in una padella, aggiungere l'olio e mescolare per ungerle uniformemente. Cuocere a fuoco medio, prima dal lato della buccia e poi su tutti i lati, finché non saranno tenere e ben dorate. Trasferire le melanzane ancora calde direttamente nella ciotola con la salsa. Aggiungere la maggior parte dello shiso (tenendone un po' da parte per la guarnizione) e mescolare bene il tutto. Impiattare subito e guarnire con lo shiso rimasto.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/sides/nametake": {
     "docId": "ricette/sides/nametake",
@@ -1225,7 +1277,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaio di Aceto di Riso"
     ],
     "instructionsText": "Per iniziare, prendi il mazzetto di funghi Enoki e rimuovi con un coltello la base del cespo (la parte con le radici), quindi taglia i funghi restanti in tre parti uguali. Trasferisci tutto in un pentolino e aggiungi direttamente a freddo i condimenti: la salsa di soia, il mirin, il sake e il cucchiaino di zucchero. Accendi il fornello e fai cuocere a fuoco medio per circa 5 minuti, mescolando di tanto in tanto; noterai che i funghi rilasceranno la loro acqua e si ammorbidiranno rapidamente. Quando la salsa di cottura si sarà leggermente ritirata e addensata, versa un cucchiaio di aceto di riso e lascia andare sul fuoco ancora per un paio di minuti per far amalgamare bene i sapori. A questo punto il Nametake è pronto: puoi servirlo immediatamente sopra una ciotola di riso fumante o trasferirlo in un barattolo per conservarlo in frigorifero.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-12-28T19:43:10+01:00"
   },
   "ricette/sides/nasu_dengaku": {
     "docId": "ricette/sides/nasu_dengaku",
@@ -1241,7 +1294,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Metti subito a scaldare il grill del forno Tagliare la melanzana in 2, e inciderla a losanga (profondità’ 4-5 mm) per farla cuocere più’ uniformemente Mettere le melanzane in una padella con poco olio (arachide o girasole) caldo, dal lato della pelle, e farle cuocere senza coperchio per 2-3 minuti, girarle e farle cuocere dall’altro lato per altri 2-3 minuti. Se sono molto spesse mettere il coperchio. Mettere le melanzane in una teglia e spennellarle con la glassatura di miso, finire la cottura in forno con il grill al massimo, per 5 minuti o finche non sono dorate Vacci piano col miso che senno’ ti vengono salate Guarnire con negi (o cipolline)",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-06-07T17:54:44+02:00"
   },
   "ricette/sides/nasu_no_yaki-bitashi": {
     "docId": "ricette/sides/nasu_no_yaki-bitashi",
@@ -1258,7 +1312,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "recipeYield": null,
     "recipeIngredient": [],
     "instructionsText": "Preparare il brodo di marinatura mescolando in una caraffa l'acqua, la salsa di soia, il mirin, lo zucchero, il dashi in polvere e lo zenzero grattugiato. Lavare e asciugare molto bene le melanzane. Rimuovere il picciolo e tagliarle a metà per il lungo. Con un coltello, incidere la superficie della buccia con tagli diagonali poco profondi, per favorire la cottura e l'assorbimento del sapore. Disporre le melanzane in una padella capiente. Spennellarle uniformemente su tutta la superficie (prima la buccia, poi la polpa) con i due cucchiai di olio. Cuocere a fuoco medio con la buccia rivolta verso il basso per circa 2-3 minuti. Girare le melanzane, abbassare la fiamma al minimo, coprire con un coperchio e cuocere lentamente finché la polpa non sarà tenera e ben dorata. Versare il brodo preparato direttamente nella padella sopra le melanzane. Alzare la fiamma a fuoco medio e portare a ebollizione. Appena il liquido bolle, spegnere immediatamente il fuoco. Trasferire con delicatezza le melanzane e tutto il loro brodo in un contenitore per alimenti. Lasciare raffreddare completamente a temperatura ambiente, dopodiché coprire e riporre in frigorifero a insaporire per almeno 3 ore. Servire le melanzane fredde, irrorandole con il loro brodo di marinatura e guarnendo a piacere con foglie di shiso tritate o katsuobushi.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/sides/potetosarada": {
     "docId": "ricette/sides/potetosarada",
@@ -1287,7 +1342,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Pepe qb"
     ],
     "instructionsText": "Mettere a bollire le patate. Tagliare il cetriolo e la cipolla sottilissimi, metterli in uno scolapasta con un po' di sale e metterci sopra un canovaccio con un peso. Far drenare per 15-20 minuti. Dopo, eliminare il sale in eccesso (anche con una sciaquata veloce) e strizzare bene con un canovaccio (mi raccomando bene) Sbollentare le carota sbucciate per qualche minuto, poi tagliarle a fettine o cubetti (come prederite) Una volta che le patate sono pronte, sbucciarle senza scottarsi, metterle in una terrina e schiacciarle con una forchetta come per fare il pure', lasciando dei pezzetti per avere una consistenza piu' varia (aho poi a me piacciono cosi poi voi fate come vi pare) Aggiungere cetriolo, cipolla, carota, la maionese, il mirin e l'aceto di riso, lo zucchero, il sale e il pepe e mescolare. I condimenti finali vanno un po' a piacere, soprattutto per quanto riguarda lo zucchero.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-04T12:25:47+02:00"
   },
   "ricette/sides/unagi-di-melanzane": {
     "docId": "ricette/sides/unagi-di-melanzane",
@@ -1319,7 +1375,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Cipolline verdi per guarnire"
     ],
     "instructionsText": "Sbucciare una striscia sì e una striscia no (come la divisa della Juve). Poi incartarla in un foglio di carta da cucina bagnato e strizzato, e poi nella pellicola per alimenti. Così avvolta, metterla in un microonde per 2-3 minuti alla massima potenza per accelerare la cottura. Scartarla e, con una forchetta, incidere dei solchi sulla polpa nel senso della lunghezza per imitare la consistenza di un'anguilla. Dopodiché, spennellarla con della fecola di patate, spennellando via l'eccesso. La salsa di cottura: In una ciotolina prepariamo la salsa mescolando sakè, mirin, salsa di soia e lo zucchero. In padella!: Metterla in una padella con un filo d'olio di semi e ripassarla a fuoco medio da ambo i lati, per farla diventare fuori croccantissima e dentro morbidissima. La glassatura: A questo punto, le concediamo un bel bagnetto versando la salsa di cottura direttamente in padella. A fuoco lentissimo, lasciamo che la salsa si riduca e glassi la melanzana. Ecco la trasformazione. Il gran finale: \"Sono un'anguilla, sono un'anguilla!\" gridava la nostra melanzana. E le fu preparato un letto di riso trionfale su cui fu dolcemente adagiata. Per guarnirla, come farle mancare dei semi di sesamo appena tostati e delle gloriose cipolline verdi? E la nostra melanzana è diventata un'anguilla.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-03T20:09:44+02:00"
   },
   "ricette/tsukemono/daikon": {
     "docId": "ricette/tsukemono/daikon",
@@ -1342,7 +1399,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "⅓ cup sugar (provato con 2 cucchiai grandi)"
     ],
     "instructionsText": "Taglia il daikon a meta', e poi a fettine di 5mm circa di spessore, ottenendo delle mezze lune. Mischia tutto molto bene e metti in un sacchetto di plastica a chiusura ermetica, cercando di far uscire tutta l'aria. All'inizio il liquido di marinatura sembrera' un po' poco, ma con il tempo il daikon, grazie al sale, espellera' un sacco di acqua. Metti in frigorifero, e' buono dopo 2-3 ore, ma suggerisco di aspettare almeno una settimana. Non ho idea di quanto si conservi, ma ne ho trovato uno dimenticato in frigo da mesi, ed era il migliore che avessi provato (e sono ancora vivo mesi dopo). Suppongo che se vada a male, sia anche facile accorgersene.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2021-08-13T18:10:22+02:00"
   },
   "ricette/tsukemono/daikon_shiokombuzuke": {
     "docId": "ricette/tsukemono/daikon_shiokombuzuke",
@@ -1370,7 +1428,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per prima cosa, prepara il daikon: taglialo in pezzi lunghi circa 6-7 cm, poi affettalo e ricavane delle listarelle. Metti le listarelle in una ciotola capiente e aggiungi il sale (\"copioso\", circa due cucchiai per mezzo chilo di daikon). Mischia bene con le mani per distribuirlo ovunque. Trasferisci il tutto in un colino, posiziona un piattino con un peso sopra (un barattolo pieno d'acqua va benissimo) e lascia riposare per circa mezz'ora. Il daikon rilascerà moltissima acqua. Passata la mezz'ora, sciacqua velocemente il daikon sotto l'acqua corrente per rimuovere il sale in eccesso. Ora la parte fondamentale: strizzalo con forza! Prendi un barattolo di vetro e inizia a comporre gli strati alternando: 1. Una dose di Daikon strizzato; 2. Una presa di Shio Kombu (l'ingrediente segreto, una vera bomba umami); 3. Un po' di peperoncino. Ripeti fino a riempire il barattolo. Per il condimento finale, versa nel barattolo: l'olio di sesamo, la salsa di soia e lo zucchero. Chiudi il barattolo e agita energicamente per amalgamare tutto. Metti in frigorifero. Sebbene basti qualche ora, lasciarlo riposare una notte intera è il top per far insaporire bene il tutto. Si conserva per qualche giorno, ma è così buono che finirà subito! Itadakimasu!",
     "videoIds": [
       "OoqRYJGzWmA"
-    ]
+    ],
+    "datePublished": "2025-12-17T17:44:02+01:00"
   },
   "ricette/tsukemono/gari": {
     "docId": "ricette/tsukemono/gari",
@@ -1387,7 +1446,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Sbuccia lo zenzero raschiandolo con un cucchiaio, e lavalo con acqua fredda. Taglialo a fettine sottili, usando un pelapatate o una mandolina, e mettile in una ciotola. Aggiungi un cucchiaio di sale e lascia riposare per 10 minuti, viene meglio ancora se lo metti sotto un peso per far rilasciare il liquido. Intanto metti una pentola con l'acqua sul fuoco, e porta a bollore. Strizza bene lo zenzero, e mettilo a bollire per 1-2 minuti. Se lo zenzero e' molto piccante, puoi bollirlo per 2-3 minuti. Scolalo bene e distribuiscilo su un panno pulito, e lascialo asciugare finche' non si fredda completamente. Strizzalo bene e mettilo in un barattolo di vetro sterilizzato. Mentre lo zenzero asciuga, prepara l'amazu. Metti l'aceto, lo zucchero e il sale in una pentola, e porta a bollore. Lascia bollire per 1-2 minuti, finche' lo zucchero non si e' sciolto completamente. Lascia raffreddare completamente. Versa l'amazu sullo zenzero, e lascia riposare per 1-2 giorni prima di consumarlo. Si conserva per mesi in frigo.",
     "videoIds": [
       "eRxAtgrW2CE"
-    ]
+    ],
+    "datePublished": "2023-10-21T11:35:53+02:00"
   },
   "ricette/tsukemono/kyuri-no-tsukemono": {
     "docId": "ricette/tsukemono/kyuri-no-tsukemono",
@@ -1406,7 +1466,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di senape Karashi (in alternativa, va bene anche la senape comune)"
     ],
     "instructionsText": "Per prima cosa, preparare il cetriolo. Con la lama di un coltello, raschiare via le asperità dalla buccia. Spargere un po' di sale su un tagliere e massaggiare vigorosamente il cetriolo sul sale per qualche istante. Eliminare il sale in eccesso e inserire il cetriolo (tagliato a metà se necessario) in un sacchetto di plastica per alimenti. Aggiungere nel sacchetto i due cucchiaini di sushisu e il cucchiaino di senape. Per creare un effetto \"sottovuoto dei poveri\", immergere il sacchetto in acqua (lasciando l'apertura fuori) per far uscire tutta l'aria, quindi sigillarlo. Mettere il sacchetto in frigorifero a marinare per qualche ora. Una volta pronto, togliere il cetriolo dal sacchetto, tagliarlo in quarti per il lungo, eliminare i semi interni e poi tagliarlo a tocchetti. Disporre i pezzi su un piattino, condire con un po' del liquido di marinatura avanzato nel sacchetto e servire. Itadakimasu!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-03T20:09:44+02:00"
   },
   "ricette/tsukemono/ninniku-no-misozuke": {
     "docId": "ricette/tsukemono/ninniku-no-misozuke",
@@ -1427,7 +1488,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "3 teste d'aglio"
     ],
     "instructionsText": "Pulire gli spicchi d'aglio e privarli del picciolo. Sterilizzare un barattolo di vetro. Tagliare gli spicchi per il lungo e togliere l'anima. Mettere gli spicchi d'aglio su una griglia, e lasciare asciugare tutta la notte. Questo aiuta a concentrare il sapore dell'aglio e a ridurre la quantita' di umidita' al suo interno. Mescolare il miso, il sake e il mirin in un piccolo pentolino, e scaldare mischiando per 2-3 minuti, fiche' non avra' assunto una consistenza liscia, cremosa e uniforme. Mettere il composto alternandolo a strati con l'aglio in un un barattolo. Far fermentare almeno 3 mesi in frigorifero.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-04-09T20:09:34+02:00"
   },
   "ricette/tsukemono/ninniku-shoyuzuke": {
     "docId": "ricette/tsukemono/ninniku-shoyuzuke",
@@ -1446,7 +1508,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1/2 tazza di aceto di riso"
     ],
     "instructionsText": "Mettere la salsa di soia, lo zucchero e l'aceto di riso in un pentolino, portare a bollore e spegnere il fuoco. Versare il preparato in un barattolo di vetro sterilizzato insieme all'aglio. Chiudere il barattolo e mettere in frigo. Il composto e' pronto dopo 3-4 settimane (meglio 4-5) e si conserva in frigo almeno 12 settimane.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2022-01-17T19:27:34+01:00"
   },
   "ricette/yakimono/gyoza": {
     "docId": "ricette/yakimono/gyoza",
@@ -1476,7 +1539,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "2 cucchiai di sake"
     ],
     "instructionsText": "Tritare finemente il cavolo e metterlo in una ciotola con un cucchiaio di sale. Lasciar riposare per 10 minuti, poi sciacquate e strizzare bene il cavolo per eliminare l'acqua in eccesso. Mentre il cavolo sta li per conto suo a perdere acqua, tritare finemente l'aglio, lo zenzero e le cipolline verdi. Mettere tutto in una ciotola con la carne di maiale e gli altri ingredienti e mescolare finché non si rompono le proteine della carne e il composto diventa omogeneo e quasi colloso. Con un cucchiaino, prendere un po' di ripieno e metterlo al centro di una sfoglia di pasta per gyoza. Bagnare i bordi con un po' d'acqua e chiudere a mezzaluna, facendo delle pieghe a ventaglio. Siccome faccio pena a chiudere i gyoza, vi linko un video di come si chiudono i gyoza: link Mettete i gyoza chiusi su un foglio di carta da forno, cosparso leggermente con della fecola di patate, o amido di mais. Questo non solo evita che i gyoza si attacchino al foglio, ma l'amido, sciogliendosi nell'acqua in cottura, fara' una splendida crosticina dorata. Piu' o meno il risultato e' questo (notare quello in basso a sinistra, detto anche Gyozimodo): !Gyoza",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2024-05-07T17:16:28+02:00"
   },
   "ricette/yakimono/isobeyaki": {
     "docId": "ricette/yakimono/isobeyaki",
@@ -1498,7 +1562,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Per questa ricetta partiamo dai Kirimochi, i classici blocchetti di mochi duri e rettangolari che si trovano in commercio. Il primo passaggio è la cottura: possiamo usare una griglia a maglia fine (se avete i fornelli a gas) oppure una semplice padella antiaderente. Cuociamo il mochi a fuoco medio. Vedrete che piano piano inizierà a gonfiarsi, dorarsi in superficie e diventare morbido. Una volta grigliato, il Kirimochi cambia nome e diventa Yakimochi (letteralmente \"mochi grigliato\"). Preparate una ciotolina con della salsa di soia. Prendete il mochi caldissimo direttamente dalla griglia e tuffatelo rapidamente nella soia, rigirandolo per farlo insaporire bene su entrambi i lati. Infine, prendete una striscia di alga nori e avvolgetela intorno al mochi ancora caldo: l'alga si attaccherà grazie all'umidità della soia e al calore, permettendovi di afferrarlo con le mani (facendo attenzione a non scottarvi). Ecco a voi l'Isobeyaki, pronto per essere addentato.",
     "videoIds": [
       "4XRlLfW_Wf0"
-    ]
+    ],
+    "datePublished": "2026-01-25T16:29:55+01:00"
   },
   "ricette/yakimono/shogayaki": {
     "docId": "ricette/yakimono/shogayaki",
@@ -1519,7 +1584,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Trita finemente lo zenzero, la mela e la cipolla, poi mescolali insieme agli altri ingredienti della salsa in una ciotola. Fai qualche taglietto sui bordi e sui nervetti delle fettine, come per i saltimbocca, per evitare che si accartoccino in cottura. Infarina leggerissimamente le fettine di maiale con la fecola di patate. Così leggermente che puoi usare un pennello, come fosse cipria. Anzi, meglio dire “incipriare” le fettine piuttosto che infarinarle. Scalda una padella antiaderente con un filo di olio. Metti a rosolare tutte le fettine da un lato per circa un minuto, o poco meno, finché sono ben rosolate. Girale e cuocile dall’altro lato per circa 30 secondi. A questo punto aggiungi la salsa direttamente in padella e lascia cuocere ancora per al massimo un minuto, giusto il tempo che la carne si insaporisca bene. Togli le fettine dalla padella e fai finire di addensare la salsa. Servi gli shogayaki guarnendo con la salsa rimasta.",
     "videoIds": [
       "kq9OBEQw4E4"
-    ]
+    ],
+    "datePublished": "2021-06-07T17:46:15+02:00"
   },
   "ricette/yakimono/teriyaki_chicken": {
     "docId": "ricette/yakimono/teriyaki_chicken",
@@ -1539,7 +1605,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "La chiave per un ottimo pollo teriyaki risiede nella gestione del calore e del grasso. Iniziamo disponendo la sovracoscia in un pentolino o una padella antiaderente ancora fredda, posizionandola con il lato della pelle verso il basso. Accendiamo il fuoco e lo regoliamo al minimo: il segreto è la lentezza. Lasciamo che il pollo rosoli dolcemente per circa 7-8 minuti; questo permetterà al grasso sottocutaneo di sciogliersi lentamente, rendendo la pelle croccante e sottile. Una volta che la pelle è ben dorata, giriamo il pollo e procediamo con la cottura dell'altro lato. Durante questa fase, è fondamentale utilizzare della carta assorbente per tamponare ed eliminare tutto il grasso in eccesso rilasciato dal pollo nella padella. Questo passaggio è cruciale per evitare che la salsa finale risulti untuosa. Continuiamo la cottura per altri 3-4 minuti fino a quando entrambi i lati saranno ben rosolati, quindi togliamo temporaneamente il pollo dalla padella e lasciamolo riposare. Prepariamo ora la salsa teriyaki nella stessa padella. Versiamo il mirin e il sake, alziamo leggermente la fiamma per far evaporare l'alcol e poi aggiungiamo la salsa di soia. Quando l'intruglio inizia a sobbollire, lasciamolo restringere per circa un minuto. Reintroduciamo il pollo nella padella e iniziamo a glassarlo con cura, girandolo più volte per farlo caramellare uniformemente su tutti i lati. Vogliamo che la salsa diventi splendente e affascinante, avvolgendo il pollo come una lacca. Infine, affettiamo il pollo a striscioline, come farebbe un vero chef di Hokuto, e disponiamolo coreograficamente su un letto di riso bianco al vapore. Non dimentichiamo di versare sopra tutta la salsa rimasta nella padella: sarebbe un delitto sprecarla.",
     "videoIds": [
       "4urhrkpiV5o"
-    ]
+    ],
+    "datePublished": "2021-06-07T17:54:53+02:00"
   },
   "ricette/zuppe/misoshiru": {
     "docId": "ricette/zuppe/misoshiru",
@@ -1564,7 +1631,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "Portate il dashi a sfiorare il bollore. Se state preparando una zuppa di miso con verdure, funghi o altri ingredienti, aggiungeteli adesso e portateli a cottura prima del miso. Quando tutto è cotto, spegnete il fuoco e sciogliete il miso nel dashi aiutandovi con un setaccio o con un mestolino. Si può fare anche senza setaccio, ma in questo modo la zuppa resta più liscia e uniforme. Aggiungete il wakame, il tofu e il negi o il porro, poi servite subito.",
     "videoIds": [
       "ESa_qRjoKsI"
-    ]
+    ],
+    "datePublished": "2025-10-27T22:43:02+01:00"
   },
   "ricette/zuppe/osuimono": {
     "docId": "ricette/zuppe/osuimono",
@@ -1587,7 +1655,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Sale q.b."
     ],
     "instructionsText": "Tagliare il daikon a spicchietti e la carotina a mezze lune. Affettare la cipollina, separando la parte bianca (che andrà in cottura) da quella verde (che terremo da parte per guarnire). Mettere a scaldare il dashi vegano in una pentola. Mi raccomando, aggiungere subito il sale, non ve lo dimenticate! Appena il dashi bolle, buttare dentro tutte le verdurine tagliate: daikon, carota e la parte bianca della cipollina. Chiudere con il coperchio e cuocere per circa 10 minuti. La zuppa sarà pronta quando il daikon diventerà traslucido e stupendo. Servire la zuppa ben calda in una ciotola, guarnire con la parte verde della cipollina e completare con un filo d'olio di sesamo.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-03T20:16:10+02:00"
   },
   "ricette/zuppe/tofu_and_eggs": {
     "docId": "ricette/zuppe/tofu_and_eggs",
@@ -1614,7 +1683,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "1 cucchiaino di Fecola di patate"
     ],
     "instructionsText": "Preparare il brodo di cottura mescolando in una ciotola il dashi, la salsa di soia, il mirin e lo zucchero. Tagliare le verdure: affettare le carote a julienne, tagliare le cipolline a tocchetti grossolani e affettare i funghi shiitake dopo aver rimosso il gambo. Tagliare il tofu a cubetti non troppo piccoli. Versare il brodo preparato in un pentolino e aggiungere subito i cubetti di tofu, facendo attenzione a non romperli. Coprire e scaldare a fuoco medio per circa 10 minuti, finché non inizia a bollire. Togliere delicatamente il tofu cotto dal pentolino e metterlo da parte in un piatto fondo. Versare tutte le verdure tagliate (carote, funghi e cipolline) nello stesso brodo di cottura, coprire e cuocere per circa 5 minuti. Nel frattempo, sbattere leggermente un uovo in una ciotolina. In un'altra piccola ciotola, sciogliere la fecola di patate con un paio di cucchiai d'acqua fredda. Trascorsi i 5 minuti, versare la fecola sciolta nel pentolino con le verdure e mescolare per addensare leggermente il brodo. Creare un vortice nel brodo e versare a filo l'uovo sbattuto per creare l'effetto \"stracciatella\". Versare le verdure e il brodo sopra il tofu messo da parte nel piatto. La ricetta è pronta, e daje!",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-10-01T15:17:03+02:00"
   },
   "ricette/zuppe/tonjiru": {
     "docId": "ricette/zuppe/tonjiru",
@@ -1650,7 +1720,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
     "instructionsText": "",
     "videoIds": [
       "StmMRRErSLQ"
-    ]
+    ],
+    "datePublished": "2025-02-15T15:15:08+01:00"
   },
   "ricette/zuppe/vegan-misoshiru": {
     "docId": "ricette/zuppe/vegan-misoshiru",
@@ -1672,7 +1743,8 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Cipolline verdi"
     ],
     "instructionsText": "Mettere in ammollo una manciata di alghe wakame in acqua fredda per farle rinvenire. Tagliare il tofu a cubetti. Portare a bollore il dashi vegano in una pentola. Appena bolle, aggiungere il tofu a cubetti e le alghe wakame reidratate. Cuocere per un paio di minuti. In una ciotolina a parte (o in un mestolo), stemperare il miso con un po' di brodo caldo per scioglierlo bene. È importante farlo a fuoco spento per non rovinare i fermenti. Spegnere il fuoco sotto la pentola e versare il miso sciolto nella zuppa. Mescolare bene. Servire subito in una ciotola e guarnire con delle cipolline fresche tagliate sottili.",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-09-05T10:46:48+02:00"
   },
   "ricette/zuppe/zuppa_di_miso_e_funghi": {
     "docId": "ricette/zuppe/zuppa_di_miso_e_funghi",
@@ -1697,6 +1769,7 @@ export const RECIPE_DATA: Record<string, RecipeData> = {
       "Cipollotto (Negi) per guarnire"
     ],
     "instructionsText": "Questa ricetta si prepara in due fasi: la preparazione del dashi (giorno 1) e la cottura della zuppa (giorno 2).",
-    "videoIds": []
+    "videoIds": [],
+    "datePublished": "2025-11-16T17:49:50+01:00"
   }
 };


### PR DESCRIPTION
## Summary

Primo step della **Fase A5** — completa lo schema Recipe di A4 aggiungendo `video` (VideoObject) per le 30 ricette con tutorial YouTube. Risolve il warning `video` del Rich Results Test su quelle pagine.

## Pipeline tecnica

1. **`scripts/generate-recipe-data.js`** — nuovo regex extraction dei `videoId` dal body MDX (`<YouTubeVideo videoId="..." />`, gestisce multipli + self-closing/non-self-closing). Aggiunto campo `videoIds: string[]` al `RECIPE_DATA`.

2. **`src/components/RecipeStructuredData.tsx`** — nuova helper `buildVideoObject()` che costruisce un VideoObject completo per ogni videoId, **senza chiamate API esterne**:

| Campo schema | Sorgente |
|---|---|
| `name` | `recipe.title` |
| `description` | `recipe.description` |
| `thumbnailUrl` | `https://img.youtube.com/vi/<id>/maxresdefault.jpg` (URL standard YouTube) |
| `contentUrl` | `https://www.youtube.com/watch?v=<id>` |
| `embedUrl` | `https://www.youtube.com/embed/<id>` |
| `uploadDate` | `dateModified` (proxy: non disponibile senza YouTube Data API v3) |

## Esempio output

`/ricette/dashi/` (ha 2 `<YouTubeVideo>` per Ichiban + Niban):

```json
"video": [
  {
    "@type": "VideoObject",
    "name": "Dashi",
    "description": "il brodo base per moltissime ricette",
    "thumbnailUrl": ["https://img.youtube.com/vi/SQjoBpeNOhg/maxresdefault.jpg"],
    "contentUrl": "https://www.youtube.com/watch?v=SQjoBpeNOhg",
    "embedUrl": "https://www.youtube.com/embed/SQjoBpeNOhg",
    "uploadDate": "2026-02-28T17:06:02.000Z"
  },
  {
    "@type": "VideoObject",
    ...JzrHdn_lr-I (Niban)...
  }
]
```

## Numeri

- **30 ricette** ora hanno `video` nello schema (su 72 totali)
- 42 ricette restano senza `video` (non hanno tutorial YouTube)

## Limitazione MVP

Per ricette con multipli video (es. `dashi`: Ichiban + Niban), entrambi gli VideoObject hanno `name: "Dashi"` invece di nomi specifici. Funzionale per Google, ma poco granulare. Iterazione futura potrà parsare i sub-header `### Ichiban Dashi` / `### Niban Dashi` sopra ogni `<YouTubeVideo>` per dare nomi più precisi.

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa
- [x] Verifica HTML statico: `dashi` ha 2 VideoObject, `kara-age` ha 1, `gyoza` ha `video` undefined
- [ ] **Validate Rich Results Test su deploy preview Netlify** una pagina con video (es. dashi o kara-age) → atteso il warning `video` sparito
- [ ] Re-fetch GSC dopo merge

## Cosa resta della Fase A5

I campi RECOMMENDED ma non required per lo schema Recipe che richiedono frontmatter ricetta:
- `prepTime`, `cookTime`, `totalTime` — backfill su ~70 ricette (lavoro grosso)
- `recipeYield` — già su 16 ricette (B1 di A4)
- `datePublished` — recuperabile da git first commit del file (script)
- `nutrition`, `aggregateRating` — fuori scope (no dati nutrizionali, no rating utente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)