### PR TITLE
seo(D1): FAQPage JSON-LD schema da sezioni Domande frequenti

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "prebuild": "node scripts/generate-image-metadata.js && node scripts/generate-ingredient-recipes.js && node scripts/generate-recipe-data.js && node scripts/optimize-images.js",
+    "prebuild": "node scripts/generate-image-metadata.js && node scripts/generate-ingredient-recipes.js && node scripts/generate-recipe-data.js && node scripts/generate-faq-data.js && node scripts/optimize-images.js",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/scripts/generate-faq-data.js
+++ b/scripts/generate-faq-data.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+/**
+ * Walks docs/ alla ricerca di sezioni "Domande frequenti..." nel body
+ * markdown, estrae i Q/A pair (`**Domanda?**\nRisposta...`) e produce
+ * src/data/faq-data.ts. Il file viene poi consumato da FAQStructuredData
+ * per costruire lo schema JSON-LD FAQPage.
+ *
+ * Pattern atteso nel markdown:
+ *
+ *   ## Domande frequenti sul furikake
+ *
+ *   **Cos'è il furikake?**
+ *   Risposta...
+ *
+ *   **Dove si compra?**
+ *   Risposta su piu' righe se serve.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+const ROOT = process.cwd();
+const DOCS_DIR = path.join(ROOT, 'docs');
+const OUTPUT_FILE = path.join(ROOT, 'src/data/faq-data.ts');
+
+// Header h2/h3 che inizia con "Domande frequenti" (con o senza suffix).
+const FAQ_HEADER_RE = /^#{2,3}\s+Domande\s+frequenti\b.*$/im;
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (entry.name.endsWith('.md') || entry.name.endsWith('.mdx')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function stripInlineMarkdown(s) {
+  return s
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // [text](url) -> text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')        // bold
+    .replace(/__([^_]+)__/g, '$1')            // bold alt
+    .replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '$1') // italic
+    .replace(/(?<!_)_([^_]+)_(?!_)/g, '$1')     // italic alt
+    .replace(/`([^`]+)`/g, '$1')              // inline code
+    .trim();
+}
+
+/**
+ * Estrae il body della sezione "Domande frequenti...": dal primo header
+ * che matcha FAQ_HEADER_RE fino al prossimo header dello stesso o
+ * superiore livello (oppure fine file).
+ */
+function extractFaqSection(body) {
+  const lines = body.split('\n');
+  let startIdx = -1;
+  let startLevel = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (m && /^Domande\s+frequenti\b/i.test(m[2])) {
+      startIdx = i + 1;
+      startLevel = m[1].length;
+      break;
+    }
+  }
+  if (startIdx === -1) return null;
+  let endIdx = lines.length;
+  for (let i = startIdx; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+/);
+    if (m && m[1].length <= startLevel) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join('\n');
+}
+
+/**
+ * Parsa il body della sezione FAQ in coppie {q, a}. Una Q e' un paragrafo
+ * che inizia con `**...**` e termina con `?`. La A e' tutto il testo fino
+ * alla prossima Q (o fine sezione), con righe vuote convertite in spazi.
+ */
+function parseFaqItems(sectionBody) {
+  const items = [];
+  const cleaned = sectionBody
+    .replace(/:::[^\n]*\n[\s\S]*?:::/g, '')             // admonitions
+    .replace(/<[A-Za-z][^>]*\/>/g, '')                   // self-closing JSX
+    .replace(/<[A-Za-z][^>]*>[\s\S]*?<\/[A-Za-z][^>]*>/g, ''); // paired JSX
+
+  const lines = cleaned.split('\n');
+  let current = null;
+  for (const line of lines) {
+    const qMatch = line.match(/^\*\*([^*]+\?)\*\*\s*$/);
+    if (qMatch) {
+      if (current) items.push(current);
+      current = {q: stripInlineMarkdown(qMatch[1]), parts: []};
+    } else if (current) {
+      current.parts.push(line);
+    }
+  }
+  if (current) items.push(current);
+
+  return items
+    .map(({q, parts}) => {
+      const a = parts
+        .map((l) => stripInlineMarkdown(l).trim())
+        .filter(Boolean)
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      return {q, a};
+    })
+    .filter((it) => it.a.length > 0);
+}
+
+function docIdFromPath(filePath) {
+  return path
+    .relative(DOCS_DIR, filePath)
+    .replace(/\\/g, '/')
+    .replace(/\.(md|mdx)$/, '');
+}
+
+function main() {
+  const files = walk(DOCS_DIR);
+  const byId = Object.create(null);
+
+  for (const f of files) {
+    const raw = fs.readFileSync(f, 'utf-8');
+    const {data, content} = matter(raw);
+    if (data.draft === true) continue;
+    if (!FAQ_HEADER_RE.test(content)) continue;
+
+    const sectionBody = extractFaqSection(content);
+    if (!sectionBody) continue;
+    const items = parseFaqItems(sectionBody);
+    if (items.length === 0) continue;
+
+    byId[docIdFromPath(f)] = items;
+  }
+
+  const header = `// AUTO-GENERATED da scripts/generate-faq-data.js — non editare a mano.\n// Estratto dalle sezioni "Domande frequenti..." nei docs/. Rigenerato dal prebuild.\n\nexport interface FaqItem {\n  q: string;\n  a: string;\n}\n\nexport const FAQ_DATA: Record<string, FaqItem[]> = `;
+
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), {recursive: true});
+  fs.writeFileSync(OUTPUT_FILE, header + JSON.stringify(byId, null, 2) + ';\n', 'utf-8');
+
+  const total = Object.values(byId).reduce((acc, arr) => acc + arr.length, 0);
+  console.log(`✅ Generated ${path.relative(ROOT, OUTPUT_FILE)} with ${Object.keys(byId).length} pages, ${total} Q/A.`);
+}
+
+main();

--- a/src/components/FAQStructuredData.tsx
+++ b/src/components/FAQStructuredData.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import {FAQ_DATA, type FaqItem} from '@site/src/data/faq-data';
+
+/**
+ * Inietta lo schema JSON-LD `FAQPage` sulle pagine che hanno una sezione
+ * "Domande frequenti..." nel body markdown. Le Q/A sono estratte dal
+ * prebuild script generate-faq-data.js — il componente legge solo dal
+ * mapping pre-calcolato in FAQ_DATA.
+ */
+export default function FAQStructuredData(): React.ReactElement | null {
+  const {metadata} = useDoc();
+  const items: FaqItem[] | undefined = FAQ_DATA[metadata.id];
+  if (!items || items.length === 0) return null;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: items.map((it) => ({
+      '@type': 'Question',
+      name: it.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: it.a,
+      },
+    })),
+  };
+
+  return (
+    <Head>
+      <script type="application/ld+json">{JSON.stringify(schema)}</script>
+    </Head>
+  );
+}

--- a/src/data/faq-data.ts
+++ b/src/data/faq-data.ts
@@ -1,0 +1,136 @@
+// AUTO-GENERATED da scripts/generate-faq-data.js — non editare a mano.
+// Estratto dalle sezioni "Domande frequenti..." nei docs/. Rigenerato dal prebuild.
+
+export interface FaqItem {
+  q: string;
+  a: string;
+}
+
+export const FAQ_DATA: Record<string, FaqItem[]> = {
+  "ingredienti/beni_shoga": [
+    {
+      "q": "Beni shoga e gari sono la stessa cosa?",
+      "a": "No. Il beni shoga è zenzero a julienne marinato nell'umezu (l'aceto delle umeboshi): rosso vivo, salato, deciso. Il gari è invece zenzero a fettine sottili marinato in amazu (aceto di riso e zucchero): rosa pallido o giallo, dolce-acidulo. Gli usi sono diversi: il beni shoga accompagna fritti e piatti alla griglia, il gari pulisce il palato fra le portate di sushi."
+    },
+    {
+      "q": "Su quali piatti si usa il beni shoga?",
+      "a": "È la guarnizione tradizionale di yakisoba, takoyaki, okonomiyaki, gyudon e di molti piatti fritti. Aggiunge una spinta acida e salata che taglia la grassezza e ravviva il piatto a livello visivo."
+    },
+    {
+      "q": "Dove comprare il beni shoga in Italia?",
+      "a": "Lo si trova in vasetto nei negozi di alimentari asiatici e nei marketplace specializzati. In alternativa è facile da preparare in casa: bastano zenzero giovane, umezu e qualche giorno in frigorifero."
+    }
+  ],
+  "ingredienti/furikake": [
+    {
+      "q": "Cos'è il furikake?",
+      "a": "Il furikake è una granella secca giapponese usata per condire il riso bianco. È un mix bilanciato di alga nori, sesamo, sale, a volte zucchero e spesso katsuobushi (tonnetto essiccato), pesce o vegetali aromatici, che aggiunge umami e croccantezza al riso e ad altri piatti."
+    },
+    {
+      "q": "Dove comprare il furikake in Italia?",
+      "a": "Il furikake si trova nei negozi di alimentari asiatici e nelle sezioni etniche dei supermercati più forniti. Esistono decine di varianti: la versione \"nori sesamo\" è la più diffusa e versatile per iniziare."
+    },
+    {
+      "q": "Differenza tra furikake e kizami nori?",
+      "a": "Il kizami nori è semplicemente alga nori tagliata a striscioline. Il furikake è invece un condimento composto: contiene nori, ma anche sesamo, sale, zucchero e altri ingredienti macinati o essiccati. Il furikake è un condimento \"completo\", il kizami nori è una guarnizione mono-ingrediente."
+    }
+  ],
+  "ingredienti/kizami_nori": [
+    {
+      "q": "Cosa sono le kizami nori?",
+      "a": "Sono fogli di alga nori essiccata tagliati in strisce sottili, lunghe pochi centimetri. Si vendono già tagliate, in bustina, e si usano come guarnizione finale per ramen, soba, riso, onigiri, sushi e molti altri piatti."
+    },
+    {
+      "q": "Differenza tra kizami nori e nori in fogli?",
+      "a": "È solo questione di formato: l'alga è la stessa. I fogli interi (yaki nori) si usano per avvolgere maki e onigiri o per fare wraps. Le kizami nori sono già tagliate e si spargono direttamente sul piatto come finitura."
+    },
+    {
+      "q": "Dove comprare le kizami nori?",
+      "a": "Si trovano facilmente nei negozi di alimentari asiatici e online. In emergenza, basta tagliare a strisce sottili un foglio di nori da sushi con le forbici da cucina: il risultato è praticamente identico."
+    }
+  ],
+  "ingredienti/miso": [
+    {
+      "q": "Che cos'è il miso?",
+      "a": "Il miso è una pasta giapponese ottenuta dalla fermentazione di soia, sale e koji (un riso o orzo inoculato con la muffa Aspergillus oryzae). La fermentazione, da pochi mesi a diversi anni, sviluppa un sapore profondo, salato e ricchissimo di umami che è alla base di moltissimi piatti giapponesi."
+    },
+    {
+      "q": "Quanti tipi di miso esistono?",
+      "a": "I quattro più comuni sono shiromiso (bianco, dolce e delicato), akamiso (rosso, intenso e salato), hatchomiso (solo soia, scuro e complesso) e mugimiso (con orzo, leggermente dolce e fruttato). In linea generale: più chiaro il colore, più breve la fermentazione, più dolce e leggero il sapore."
+    },
+    {
+      "q": "Dove comprare il miso in Italia?",
+      "a": "Il miso si trova nei negozi di alimentari asiatici, nei negozi bio (sia industriale sia artigianale) e nelle sezioni etniche dei supermercati ben forniti. Per iniziare basta una vaschetta di shiromiso o un miso \"all-purpose\": una volta aperto, dura mesi in frigorifero."
+    }
+  ],
+  "ingredienti/natto": [
+    {
+      "q": "Cos'è il natto?",
+      "a": "Il natto è un alimento tradizionale giapponese a base di semi di soia fermentati con il Bacillus subtilis natto. La fermentazione gli dà la sua caratteristica consistenza appiccicosa e filante, un aroma intenso e un sapore forte. È un superfood ricco di proteine, fibre, vitamina K2 e probiotici."
+    },
+    {
+      "q": "Come si mangia il natto?",
+      "a": "Il modo più tradizionale è sul riso bianco caldo, mescolato per attivare i fili (di solito 30-50 colpi di bacchetta), con un cucchiaino di salsa di soia e una punta di karashi o senape. Si usa anche dentro al sushi, nelle insalate, in zuppe e omelette. Spesso si mangia a colazione."
+    },
+    {
+      "q": "Dove comprare il natto in Italia?",
+      "a": "Il natto si trova surgelato o refrigerato nei negozi di alimentari giapponesi e asiatici più forniti, soprattutto a Milano, Roma, Torino e nelle altre grandi città. Si conserva benissimo in congelatore: si scongela in pochi minuti a temperatura ambiente."
+    }
+  ],
+  "ingredienti/senape_karashi": [
+    {
+      "q": "Cos'è il karashi?",
+      "a": "Il karashi è la senape giapponese: una pasta gialla densa fatta di semi di senape macinati, senza zucchero né aceto. È molto più piccante della senape europea e ha un effetto pungente simile al wasabi."
+    },
+    {
+      "q": "Karashi e senape europea: che differenza c'è?",
+      "a": "La senape europea (Dijon, in grani, miele) contiene aceto, zucchero, vino e spezie che ne ammorbidiscono il sapore. Il karashi è puro: solo semi di senape e acqua. Il risultato è una pasta più piccante, asciutta e pungente, da usare in piccolissime quantità."
+    },
+    {
+      "q": "Cosa usare al posto del karashi?",
+      "a": "Il sostituto più vicino è la senape inglese (English mustard, tipo Colman's), che ha un profilo simile per piccantezza e assenza di dolcificanti. In emergenza si può usare un mix di senape forte + un pizzico di wasabi."
+    }
+  ],
+  "ingredienti/shiso": [
+    {
+      "q": "Cos'è lo shiso?",
+      "a": "Lo shiso (Perilla frutescens) è un'erba aromatica giapponese della famiglia della menta. Ne esistono due varietà principali: lo shiso verde (aoshiso), più fresco e citrico, e lo shiso rosso (akashiso), più pungente e usato per colorare gli umeboshi e i sottaceti."
+    },
+    {
+      "q": "Shiso e basilico: che differenza c'è?",
+      "a": "Pur appartenendo entrambi alla famiglia delle Lamiaceae, hanno profili aromatici molto diversi. Lo shiso ha note di menta, anice e agrumi, ed è più pungente. Il basilico è più dolce e morbido. In emergenza, in alcune ricette, le foglie di basilico possono sostituire lo shiso, ma cambia il carattere finale del piatto."
+    },
+    {
+      "q": "Dove comprare lo shiso in Italia?",
+      "a": "Le foglie fresche di shiso si trovano stagionalmente in alcuni negozi di alimentari asiatici e online. Lo shiso essiccato (yukari) e i semi di perilla sono più facili da reperire e si conservano molto a lungo. Coltivarlo in vaso è semplicissimo: cresce come la menta."
+    }
+  ],
+  "ingredienti/yuzu": [
+    {
+      "q": "Cos'è lo yuzu?",
+      "a": "Lo yuzu è un agrume giapponese (Citrus junos), grosso più o meno quanto un mandarino, di colore giallo-verde. Pur essendo nato in Cina, è diventato un ingrediente identitario della cucina giapponese, dove si usa più la buccia profumata che la polpa."
+    },
+    {
+      "q": "Che sapore ha lo yuzu?",
+      "a": "Il profumo è molto intenso e tridimensionale: ricorda il limone con accenti di mandarino e pompelmo verde. Il succo è acido e poco zuccherino, da usare in piccole dosi. La buccia è la parte più aromatica e senza amaro percepibile."
+    },
+    {
+      "q": "Cosa usare al posto dello yuzu?",
+      "a": "Il sostituto più vicino è un mix di buccia di limone e buccia di mandarino verde, in parti uguali. Per il succo si può usare un mix di succo di limone e succo di lime. Niente avrà esattamente l'aroma dello yuzu, ma il risultato è coerente."
+    }
+  ],
+  "ricette/preparazioni_di_base/salse/tentsuyu": [
+    {
+      "q": "Cos'è la salsa tentsuyu?",
+      "a": "Il tentsuyu è la salsa tradizionale giapponese in cui si intinge il tempura appena fritto. È un brodo leggero a base di dashi, mirin e salsa di soia, spesso servito con daikon grattugiato che aggiunge freschezza e bilancia la grassezza del fritto."
+    },
+    {
+      "q": "Differenza tra tentsuyu e mentsuyu?",
+      "a": "Sono parenti stretti, ma diversi nella destinazione. Il mentsuyu è più concentrato e si usa per condire i noodle (soba e udon), allungato con acqua o servito a parte. Il tentsuyu è più diluito ed è pensato esclusivamente come salsa di intinto per il tempura."
+    },
+    {
+      "q": "Per quanto si conserva il tentsuyu?",
+      "a": "Dopo averlo preparato e raffreddato, si conserva in frigorifero per 2-3 settimane in un barattolo chiuso. Il daikon grattugiato va sempre aggiunto al momento di servire, mai conservato dentro la salsa, per non comprometterne il sapore e la durata."
+    }
+  ]
+};

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -12,6 +12,7 @@ import Heading from '@theme/Heading';
 import MDXContent from '@theme/MDXContent';
 import type {Props} from '@theme/DocItem/Content';
 import RecipeStructuredData from '@site/src/components/RecipeStructuredData';
+import FAQStructuredData from '@site/src/components/FAQStructuredData';
 
 function useSyntheticTitle(): string | null {
   const {metadata, frontMatter, contentTitle} = useDoc();
@@ -28,6 +29,7 @@ export default function DocItemContent({children}: Props): ReactNode {
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
       <RecipeStructuredData />
+      <FAQStructuredData />
       {syntheticTitle && (
         <header>
           <Heading as="h1">{syntheticTitle}</Heading>


### PR DESCRIPTION
## Summary

Fase **D1** del workplan SEO: FAQ schema. Sblocca i FAQ rich result di Google sulle 9 pagine ingrediente/ricetta che hanno già una mini-FAQ in markdown (aggiunte in A0).

**Pattern uguale ad A4** (Recipe schema): FAQ vivono come markdown nei file md, un prebuild script estrae i Q/A, un componente li inietta come JSON-LD via `<Head>`. Il proprietario continua a editare le FAQ in markdown semplice — niente JSX nei file content.

## Pipeline tecnica

1. **`scripts/generate-faq-data.js`** — walka `docs/**/*.md`, cerca header h2/h3 che inizia per "Domande frequenti", parsa coppie `**Q?**\nA` fino al prossimo header dello stesso/superiore livello. Output: `src/data/faq-data.ts`.

2. **`src/components/FAQStructuredData.tsx`** — usa `useDoc()`, lookup in `FAQ_DATA`, costruisce schema `FAQPage` con `mainEntity: [{Question, acceptedAnswer: {Answer}}]` e lo inietta via `<Head>`.

3. **`src/theme/DocItem/Content/index.tsx`** — swizzle update: `<FAQStructuredData />` accanto a `<RecipeStructuredData />`.

4. **`package.json`** — prebuild step.

## Pattern markdown atteso (già usato in A0)

```markdown
## Domande frequenti sul furikake

**Cos'è il furikake?**
Il furikake è una granella secca giapponese...

**Dove comprare il furikake in Italia?**
Si trova nei [negozi asiatici](/negozi_orientali/)...
```

Il parser pulisce inline markdown (link → testo), rimuove admonitions e componenti MDX.

## Verifica build statico

| Pagina | Schemas iniettati |
|---|---|
| `/ingredienti/furikake/` | BreadcrumbList + **FAQPage** (3 Q/A) |
| `/ingredienti/natto/` | BreadcrumbList + **FAQPage** (3 Q/A) |
| `/ricette/tentsuyu/` | BreadcrumbList + Recipe + **FAQPage** (3 Q/A) |
| `/ingredienti/miso/` | BreadcrumbList + **FAQPage** (3 Q/A) |
| `/ricette/gyoza/` | BreadcrumbList + Recipe (no FAQPage — niente sezione FAQ nel md) ✓ |

**Totale**: 9 pagine, 27 Q/A nello schema.

## Esempio output schema

```json
{
  "@context": "https://schema.org",
  "@type": "FAQPage",
  "mainEntity": [
    {
      "@type": "Question",
      "name": "Cos'è il furikake?",
      "acceptedAnswer": {
        "@type": "Answer",
        "text": "Il furikake è una granella secca giapponese..."
      }
    },
    ...
  ]
}
```

## Cosa NON cambia

- Rendering visivo delle pagine: la sezione `## Domande frequenti` resta markdown nativo (h2 + bold + paragraphs). Niente accordion né custom UI per ora.
- Il proprietario edita le FAQ esattamente come prima.

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa
- [x] Verifica HTML: 9 pagine con FAQPage schema, le altre invariate
- [ ] Validate Rich Results Test su deploy preview Netlify (es. `/ingredienti/furikake/`)
- [ ] Re-fetch GSC dopo merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)