### PR TITLE
seo(D2+D3): ItemList su list pages + WebSite/SearchAction globale

### DIFF
--- a/src/components/CategoryIndexPage.tsx
+++ b/src/components/CategoryIndexPage.tsx
@@ -3,6 +3,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/plugin-content-docs/client'
 import type {PropSidebarItem, PropSidebarItemLink, PropSidebarItemCategory} from '@docusaurus/plugin-content-docs';
 import type {DocCardDoc} from './DocCard';
 import DocCardGrid from './DocCardGrid';
+import ItemListStructuredData from './ItemListStructuredData';
 
 // Questa pagina non ha bisogno di titolo/descrizione perché il template del doc li renderizza già.
 export default function CategoryIndexPage(): React.ReactElement {
@@ -52,5 +53,10 @@ export default function CategoryIndexPage(): React.ReactElement {
       }));
   }, [category]);
 
-  return <DocCardGrid docs={docs} />;
+  return (
+    <>
+      <ItemListStructuredData docs={docs} name={category?.label} />
+      <DocCardGrid docs={docs} />
+    </>
+  );
 }

--- a/src/components/ItemListStructuredData.tsx
+++ b/src/components/ItemListStructuredData.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import type {DocCardDoc} from './DocCard';
+
+const FALLBACK_SITE_URL = 'https://paginegiappe.it';
+
+interface Props {
+  /** I doc renderizzati nella card grid (stesso shape di DocCardGrid). */
+  docs: DocCardDoc[];
+  /** Nome opzionale dell'ItemList (es. "Ricette giapponesi alla griglia"). */
+  name?: string;
+}
+
+/**
+ * Inietta lo schema JSON-LD `ItemList` per pagine che renderizzano una
+ * lista di doc come card (CategoryIndexPage, DocTagDocListPage). Aiuta
+ * Google a capire che la pagina e' una rassegna e non un singolo articolo.
+ */
+export default function ItemListStructuredData({docs, name}: Props): React.ReactElement | null {
+  const {siteConfig} = useDocusaurusContext();
+  const siteUrl = (siteConfig.url || FALLBACK_SITE_URL).replace(/\/$/, '');
+  if (!docs || docs.length === 0) return null;
+
+  const itemListElement = docs.map((doc, idx) => {
+    const url = doc.permalink.startsWith('http')
+      ? doc.permalink
+      : siteUrl + (doc.permalink.startsWith('/') ? doc.permalink : '/' + doc.permalink);
+    return {
+      '@type': 'ListItem',
+      position: idx + 1,
+      url,
+      name: doc.title,
+    };
+  });
+
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    numberOfItems: docs.length,
+    itemListElement,
+  };
+  if (name) schema.name = name;
+
+  return (
+    <Head>
+      <script type="application/ld+json">{JSON.stringify(schema)}</script>
+    </Head>
+  );
+}

--- a/src/theme/DocTagDocListPage/index.tsx
+++ b/src/theme/DocTagDocListPage/index.tsx
@@ -13,6 +13,7 @@ import type {Props} from '@theme/DocTagDocListPage';
 import Unlisted from '@theme/ContentVisibility/Unlisted';
 import Heading from '@theme/Heading';
 import DocCardGrid from '@site/src/components/DocCardGrid';
+import ItemListStructuredData from '@site/src/components/ItemListStructuredData';
 import styles from './styles.module.css';
 
 // Very simple pluralization: probably good enough for now
@@ -79,6 +80,7 @@ function DocTagDocListPageContent({
                 </Translate>
               </Link>
             </header>
+            <ItemListStructuredData docs={tag.items as any} name={title} />
             <DocCardGrid docs={tag.items as any} />
           </main>
         </div>

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -17,15 +17,17 @@ const SITE_URL = 'https://paginegiappe.it';
 const WEBSITE_SCHEMA = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
-  name: 'Le Ricette Giapponesi di Jeko',
-  alternateName: 'Pagine Giappe',
+  name: 'Pagine Giappe',
+  alternateName: 'Le Ricette Giapponesi di Jeko',
   url: SITE_URL + '/',
   inLanguage: 'it-IT',
   potentialAction: {
     '@type': 'SearchAction',
+    // Trailing slash perche' il sito usa trailingSlash: true (senza slash
+    // Docusaurus ridireziona 301).
     target: {
       '@type': 'EntryPoint',
-      urlTemplate: SITE_URL + '/search?q={search_term_string}',
+      urlTemplate: SITE_URL + '/search/?q={search_term_string}',
     },
     'query-input': 'required name=search_term_string',
   },

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,12 +1,38 @@
 import React from 'react';
 import type {ReactNode} from 'react';
+import Head from '@docusaurus/Head';
 
 interface Props {
   children: ReactNode;
 }
 
+const SITE_URL = 'https://paginegiappe.it';
+
 /**
- * Custom Root component to add performance optimizations to head
+ * Schema globale WebSite + SearchAction. Iniettato SSR cosi' Google lo
+ * vede al crawl. Il SearchAction punta a /search?q=... (Algolia gestisce
+ * la modal — il path e' fittizio ma semantically valido per il sitelinks
+ * search box di Google).
+ */
+const WEBSITE_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Le Ricette Giapponesi di Jeko',
+  alternateName: 'Pagine Giappe',
+  url: SITE_URL + '/',
+  inLanguage: 'it-IT',
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: SITE_URL + '/search?q={search_term_string}',
+    },
+    'query-input': 'required name=search_term_string',
+  },
+};
+
+/**
+ * Custom Root component: performance prefetch + global WebSite schema.
  */
 export default function Root({children}: Props): ReactNode {
   React.useEffect(() => {
@@ -31,5 +57,12 @@ export default function Root({children}: Props): ReactNode {
 
   }, []);
 
-  return <>{children}</>;
+  return (
+    <>
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(WEBSITE_SCHEMA)}</script>
+      </Head>
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Due schemi JSON-LD piccoli, entrambi della Fase D del workplan SEO. In una sola PR perche' entrambi banali e indipendenti.

### D3 — WebSite + SearchAction

`src/theme/Root.tsx` (swizzle gia' esistente per il prefetch DNS): aggiunto `<Head>` SSR con schema `WebSite` globale che include `potentialAction SearchAction`. L'action punta a `/search?q={search_term_string}`. Algolia gestisce internamente la modal — il path serve a Google per il **sitelinks search box** nello SERP, attivabile per query brand (es. "paginegiappe").

```json
{
  "@context": "https://schema.org",
  "@type": "WebSite",
  "name": "Le Ricette Giapponesi di Jeko",
  "alternateName": "Pagine Giappe",
  "url": "https://paginegiappe.it/",
  "inLanguage": "it-IT",
  "potentialAction": {
    "@type": "SearchAction",
    "target": { "urlTemplate": "https://paginegiappe.it/search?q={search_term_string}" },
    "query-input": "required name=search_term_string"
  }
}
```

### D2 — ItemList sulle list pages

Nuovo componente `src/components/ItemListStructuredData.tsx` — emette uno schema `ItemList` con `position` + `name` + `url` di ogni elemento. Riusato da:

- `<CategoryIndexPage />` (le pagine indice categoria: agemono, antipasti, menrui, preparazioni_di_base, brodi, salse, condimenti, sushi, ecc.)
- Swizzle `theme/DocTagDocListPage` (le pagine `/tags/<tag>`)

Aiuta Google a capire che la pagina e' una **rassegna di articoli** e non un singolo articolo — eligibile per rich result "carousel" / "list".

## Verifica build statico

| Pagina | Schemas iniettati |
|---|---|
| `/` (home) | WebSite + BreadcrumbList |
| `/ricette/agemono/` | WebSite + BreadcrumbList + **ItemList(2)** |
| `/ricette/preparazioni_di_base/` | WebSite + BreadcrumbList + **ItemList(4)** |
| `/tags/dashi/` | WebSite + **ItemList(1)** |
| `/ricette/dashi/` (single recipe) | WebSite + BreadcrumbList + Recipe (no ItemList ✓) |
| `/ingredienti/furikake/` | WebSite + BreadcrumbList + FAQPage (no ItemList ✓) |

Il `WebSite` schema appare su TUTTE le pagine (giusto, e' globale dal Root).

## Test plan

- [x] `npm run typecheck` → passa
- [x] `npm run build` → passa
- [x] Verifica HTML statico + dev preview (HMR funziona, schema visibile in `<head>`)
- [ ] Validate Rich Results Test su deploy preview (es. `/ricette/agemono/` o `/ricette/preparazioni_di_base/`)
- [ ] Re-fetch GSC dopo merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)