### PR TITLE
seo: fallback social card per Recipe.image mancante

### DIFF
--- a/src/components/RecipeStructuredData.tsx
+++ b/src/components/RecipeStructuredData.tsx
@@ -5,6 +5,10 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {RECIPE_DATA, type RecipeData} from '@site/src/data/recipe-data';
 
 const FALLBACK_SITE_URL = 'https://paginegiappe.it';
+// Schema.org Recipe richiede `image` per la validazione di Google: senza
+// immagine la ricetta viene scartata dal rich result. Quando il frontmatter
+// non specifica un'immagine, ricadiamo sul social media card del sito.
+const FALLBACK_IMAGE = '/img/social_media_card.png';
 const AUTHOR = {
   '@type': 'Person',
   name: 'Stefano Guglielmetti',
@@ -66,7 +70,7 @@ function buildRecipeSchema(
     recipeCuisine: 'Giapponese',
     keywords: keywordParts.join(', '),
   };
-  const imageUrl = absoluteUrl(siteUrl, data.image);
+  const imageUrl = absoluteUrl(siteUrl, data.image) ?? absoluteUrl(siteUrl, FALLBACK_IMAGE);
   if (imageUrl) schema.image = [imageUrl];
   if (data.recipeCategory) schema.recipeCategory = data.recipeCategory;
   if (data.recipeYield) schema.recipeYield = data.recipeYield;


### PR DESCRIPTION
## Summary

- Le ricette senza `image:` nel frontmatter emettevano un Recipe JSON-LD privo della proprietà `image`, che Google richiede come obbligatoria per i rich result. Senza di essa la pagina veniva scartata dall'indicizzazione strutturata.
- Aggiunto fallback a `/img/social_media_card.png` in [src/components/RecipeStructuredData.tsx](https://github.com/amicojeko/JapaneseCookbook/blob/claude/intelligent-hertz-00cfac/src/components/RecipeStructuredData.tsx): le ricette con immagine custom continuano a usare la propria, le altre ereditano la social card del sito.
- Il fallback vive solo nel renderer JSON-LD: `src/data/recipe-data.ts` e `scripts/generate-recipe-data.js` non cambiano, così la fonte continua a riflettere fedelmente il frontmatter (`image: null` quando manca davvero) e i consumer dei dati (es. `ricettario.json` per l'AI) possono distinguere "ricetta senza immagine reale" da "ricetta con social card".

## Test plan

- [x] Verificato in dev che la ricetta `Sudako con Negi al Vapore` (`/ricette/sudako_negi_vapore/`) — che ha `image: null` in `recipe-data.ts` — ora emette nel `<head>` un Recipe JSON-LD con `image: ["https://paginegiappe.it/img/social_media_card.png"]`.
- [ ] Sanity check su una ricetta con immagine custom: deve continuare a usare la propria, non il fallback.
- [ ] (Opzionale) Validare la pagina rigenerata con il [Rich Results Test](https://search.google.com/test/rich-results) di Google dopo il deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)