### PR TITLE
fix(seo): rimuovi twitter:title/description hardcoded site-wide

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -152,14 +152,15 @@ const config: Config = {
     },
     image: 'img/social_media_card.png',
     metadata: [
+      // Card format only. Twitter/X falls back to og:title / og:description
+      // when twitter:title / twitter:description aren't set — and Docusaurus
+      // auto-generates og:* per page from frontmatter (title / description
+      // / image), so setting twitter:title / twitter:description here would
+      // hardcode site-wide strings on every page (already happened: blog
+      // posts showed "Le ricette giapponesi di Jeko" instead of the post
+      // title on X cards). Keep this minimal; let og:* be the single source
+      // of truth. twitter:image is auto-emitted per page by Docusaurus.
       {name: 'twitter:card', content: 'summary_large_image'},
-      {name: 'twitter:title', content: 'Le ricette giapponesi di Jeko'},
-      {
-        name: 'twitter:description',
-        content:
-          'Tutte le ricette giapponesi spiegate passo passo, con foto e video. Scopri i segreti della cucina giapponese con Jeko!'
-      },
-      {name: 'twitter:image', content: 'img/social_media_card.png'},
       {
         name: 'description',
         content: 'Tutte le ricette giapponesi spiegate passo passo, con foto e video. Scopri i segreti della cucina giapponese con Jeko!'


### PR DESCRIPTION
## Summary

In `themeConfig.metadata` erano inchiodati `twitter:title` e `twitter:description` ai valori del sito. Su ogni pagina, anche sui post del blog, le card di Twitter/X mostravano quindi sempre "Le ricette giapponesi di Jeko" + tagline, invece che titolo e descrizione del post. Facebook / LinkedIn / Slack / WhatsApp (che leggono `og:*`) andavano già bene perché Docusaurus auto-emette `og:title` / `og:description` / `og:image` per-pagina dalla frontmatter — ma non i `twitter:*` equivalenti, motivo per cui quei due restavano statici.

Fix: rimuoverli. Twitter/X cade nativamente sui `og:*` quando i `twitter:*` specifici sono assenti ([doc ufficiale X](https://developer.x.com/en/docs/x-for-websites/cards/overview/markup)), così tutta la SEO social ha un'unica fonte di verità: la frontmatter di ogni pagina. Tenuto `twitter:card` (formato) e `twitter:image` (Docusaurus la auto-emette per-pagina).

## Test plan

- [x] `npm run build` passa pulito
- [x] `build/blog/pesce-guarda-a-sinistra/index.html` ora espone `og:title` / `og:description` / `og:image` del post; nessun `twitter:title` / `twitter:description` residuo
- [x] `build/index.html` (homepage) espone i meta del sito come prima
- [ ] Post-deploy: validare 1-2 URL su [X Card Validator](https://cards-dev.twitter.com/validator) per conferma visiva

🤖 Generated with [Claude Code](https://claude.com/claude-code)