### PR TITLE
chore(brand): rinomina sito a "Pagine Giappe"

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -5,7 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'Le Ricette Giapponesi di Jeko',
+  title: 'Pagine Giappe',
   tagline: 'La Jekucina a casa tua!',
   // Use a typographic middle dot in <title> tags ("Page · Site") instead of
   // the default pipe — cleaner on the SERP and the browser tab.
@@ -175,7 +175,7 @@ const config: Config = {
       respectPrefersColorScheme: false,
     },
     navbar: {
-      title: 'Paginegiappe.it',
+      title: 'Pagine Giappe',
       logo: {
         alt: 'Jeko',
         src: 'img/logo_katakana.png',


### PR DESCRIPTION
## Summary

`siteConfig.title` passa da **"Le Ricette Giapponesi di Jeko"** a **"Pagine Giappe"**. Anche `themeConfig.navbar.title` passa da "Paginegiappe.it" a "Pagine Giappe" per coerenza visiva.

**Perché**: la forma precedente era una *tagline* travestita da brand — lunga 30 char (Google tronca i `<title>` SERP sopra ~60 char, quindi veniva mangiata), pinned a "ricette" mentre il sito ormai include libri, viaggi, negozi e un blog multi-autore. "Pagine Giappe" è la forma umana del dominio: è come la gente cerca ("pagine giappe ramen"), coerente con la card social (il dominio compare già sotto al titolo) e neutrale rispetto agli autori del blog.

**Cascading**: cambiare `siteConfig.title` aggiorna in automatico **tutti** i `<title>` HTML del sito (pattern Docusaurus = `{page title} · {site title}`), gli `og:title` per-pagina, e di riflesso le card social su X (dopo il merge di [#28](https://github.com/amicojeko/JapaneseCookbook/pull/28) che le aveva sganciate da valori hardcoded).

**Preservato**: la forma estesa "Le Ricette Giapponesi di Jeko" rimane come `alternateName` nel JSON-LD `WebSite` in `src/theme/Root.tsx` (Google la conosce per Knowledge Graph). La tagline "La Jekucina a casa tua!" resta invariata (voce personale, non brand).

## Test plan

- [x] `npm run build` passa pulito
- [x] Verifica `<title>` SSR'd in `build/`:
  - Home → `... · Pagine Giappe`
  - Blog post `/blog/pesce-guarda-a-sinistra/` → `... · Pagine Giappe`
  - Ricetta `/ricette/dashi/` → `Dashi · Pagine Giappe`
- [x] Navbar mostra "Pagine Giappe"
- [ ] Post-deploy: Google riprenderà i nuovi `<title>` al prossimo crawl (1-7 giorni di norma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)