### PR TITLE
feat(blog): CTA "Leggi l'articolo completo →" più evidente sulla lista

### DIFF
--- a/i18n/it/code.json
+++ b/i18n/it/code.json
@@ -203,11 +203,11 @@
     "description": "The label used by the button on the collapsible TOC component"
   },
   "theme.blog.post.readMore": {
-    "message": "Leggi di più",
+    "message": "Leggi l'articolo completo",
     "description": "The label used in blog post item excerpts to link to full blog posts"
   },
   "theme.blog.post.readMoreLabel": {
-    "message": "Leggi di più su {title}",
+    "message": "Leggi l'articolo completo: {title}",
     "description": "The ARIA label for the link to full blog posts from excerpts"
   },
   "theme.blog.post.readingTime.plurals": {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1447,23 +1447,43 @@ article > .theme-doc-markdown.markdown > p:first-of-type::first-letter,
   padding-top: 14px;
   margin-top: 18px;
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > footer a.button {
-  font-family: var(--pg-font-sans);
-  font-weight: 700;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  border: 2px solid var(--pg-ink);
-  background: var(--pg-yellow);
-  color: var(--pg-ink);
-  border-radius: 999px;
-  padding: 8px 16px;
+/* "Leggi l'articolo completo →" CTA on list/tag/author pages.
+   Docusaurus renders this as a plain <a><b>label</b></a> in
+   .col.text--right (no .button class), so we target that path
+   directly. The arrow is a CSS pseudo so it can animate on hover
+   without bloating the translation string. */
+:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
+    article > footer .col.text--right > a {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--pg-font-serif);
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.005em;
+  color: var(--pg-red);
+  text-decoration: none;
+  border-bottom: 0;
+  transition: color 0.15s ease;
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > footer a.button:hover {
-  background: var(--pg-ink);
-  color: var(--pg-yellow);
+:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
+    article > footer .col.text--right > a > b {
+  font-weight: inherit;
+}
+:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
+    article > footer .col.text--right > a::after {
+  content: '→';
+  font-weight: 700;
+  display: inline-block;
+  transition: transform 0.18s ease;
+}
+:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
+    article > footer .col.text--right > a:hover {
+  color: var(--pg-red-ink);
+}
+:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
+    article > footer .col.text--right > a:hover::after {
+  transform: translateX(5px);
 }
 
 /* Tag chips inside an article */


### PR DESCRIPTION
## Summary

L'attuale `Leggi di più` in fondo a ogni excerpt nella lista blog è un link rosso piccolo, **indistinguibile da un qualsiasi link inline dentro al body** del post. Risultato: l'invito a leggere il pezzo completo passa inosservato.

Lo trasformo in un link editoriale prominente (senza pillola — su richiesta esplicita di non andare in modalità bottone):

- Label: **`Leggi l'articolo completo`** (più esplicito di `di più`, dice cosa succede)
- Font Fraunces serif bold 18px (1px più del corpo, weight 800)
- Freccia `→` via `::after` (così non è inchiodata nella traduzione, può animarsi)
- Hover: la freccia scivola 5px a destra, il colore vira a `--pg-red-ink`
- ARIA label allineato: `Leggi l'articolo completo: {title}`

## Implementazione

- `i18n/it/code.json`: override delle stringhe `theme.blog.post.readMore` e `theme.blog.post.readMoreLabel` (Docusaurus le pesca da qui per il locale `it`)
- `src/css/custom.css`: scope `:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article > footer .col.text--right > a` — solo nelle viste-elenco, non sulla pagina singola del post (dove l'utente è già nell'articolo)

## Test plan

- [x] `npm run build` passa pulito
- [x] Tutti gli excerpt nella build di `/blog/`, `/blog/tags/<tag>/`, `/blog/authors/<author>/` mostrano `<b>Leggi l'articolo completo</b>` con aria-label `Leggi l'articolo completo: {title}`
- [ ] Visual check post-deploy: link rosso bold 18px, freccia animata in hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)