### PR TITLE
fix(images): sizes hint coerenti con la larghezza reale delle card

### DIFF
--- a/src/components/DocCard.tsx
+++ b/src/components/DocCard.tsx
@@ -28,6 +28,11 @@ export default function DocCard({doc}: DocCardProps): React.ReactElement {
             alt={doc.title}
             className={styles.image}
             pictureClassName={styles.picture}
+            // DocCardGrid è auto-fill minmax(280px, 1fr): card 200-340px
+            // (1 colonna sotto i ~424px, 2-4 colonne sopra). Sotto i 480px
+            // diciamo 100vw (card singola), sopra fissiamo ~320px che è la
+            // larghezza tipica della card multi-colonna.
+            sizes="(max-width: 480px) 100vw, 320px"
           />
         </div>
         <div className={styles.content}>

--- a/src/components/LatestBlogPosts.tsx
+++ b/src/components/LatestBlogPosts.tsx
@@ -41,7 +41,14 @@ function PostCard({post}: {post: BlogIndexEntry}): React.ReactElement {
       <article className={styles.card}>
         {post.image && (
           <div className={styles.imageWrapper}>
-            <OptimizedImage src={post.image} alt={post.title} className={styles.image} />
+            <OptimizedImage
+              src={post.image}
+              alt={post.title}
+              className={styles.image}
+              // Strip auto-fill minmax(300px, 1fr): card 340-450px
+              // (1 col su mobile, 2 col su tablet, 3-4 col su desktop).
+              sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 360px"
+            />
           </div>
         )}
         <div className={styles.content}>

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -21,7 +21,19 @@ interface OptimizedImageProps {
   /** Optional explicit dims (overrides manifest width/height). */
   width?: number | string;
   height?: number | string;
+  /**
+   * `sizes` attribute hint. Without it the browser assumes the image
+   * occupies 100vw and picks oversized variants — es. 640w o più
+   * per una card della home che in realtà è 286px (1280 viewport, 4 col)
+   * o 220px (768 viewport, 3 col). Tipici buoni valori:
+   *   - card grid auto-fill min-280px:  "(max-width: 480px) 100vw, 320px"
+   *   - inline content (~720px col):     "(max-width: 720px) 100vw, 720px"
+   * Default: content-column (720px).
+   */
+  sizes?: string;
 }
+
+const DEFAULT_SIZES = '(max-width: 720px) 100vw, 720px';
 
 /**
  * Renders a `<picture>` that serves a WebP responsive variant from the
@@ -41,6 +53,7 @@ export default function OptimizedImage({
   style,
   width,
   height,
+  sizes = DEFAULT_SIZES,
 }: OptimizedImageProps): React.ReactElement {
   const srcsetKey = src.replace(/^\/img\//, '');
   const srcsetData = (imageSrcset as Record<string, ImageSrcsetData>)[srcsetKey] as
@@ -53,7 +66,7 @@ export default function OptimizedImage({
   if (srcsetData?.srcset) {
     return (
       <picture className={pictureClassName}>
-        <source srcSet={srcsetData.srcset} type="image/webp" />
+        <source srcSet={srcsetData.srcset} type="image/webp" sizes={sizes} />
         <img
           src={srcsetData.original || src}
           alt={alt}
@@ -63,6 +76,7 @@ export default function OptimizedImage({
           width={imgWidth}
           height={imgHeight}
           style={style}
+          sizes={sizes}
         />
       </picture>
     );


### PR DESCRIPTION
## Summary

Risolve l'over-fetch sulle card della homepage che è stato osservato post-merge della PR #33: senza l'attributo `sizes`, il browser dimensionava le immagini per 100vw → caricava varianti `640w-1600w` anche per card larghe ~220-340px.

**Misure reali (DPR=1)**:
| Viewport | Card ricette (DocCard) | Card strip (LatestBlogPosts) |
|---|---|---|
| 1440 | 339px | 347px |
| 1280 | **286px** | 453px |
| 768  | **220px** | 347px |

Le card ricette sono quasi sempre <320px → la variante 320w è perfetta.

## Cambiamenti

- **`OptimizedImage`**: nuovo prop opzionale `sizes` (default `(max-width: 720px) 100vw, 720px` per inline content). Emesso sia su `<source>` che su `<img>`.
- **`DocCard`**: `sizes="(max-width: 480px) 100vw, 320px"` → cards multi-colonna prendono 320w.
- **`LatestBlogPosts` strip**: `sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 360px"` → cards più larghe prendono 640w.

## Verifica

Sul build a vari viewport DPR=1:

| Caso | Prima | Dopo | Saving |
|---|---|---|---|
| 1280 DocCard 286px | 640w (80KB) | **320w** (25KB) | -55KB/card |
| 1280 strip 453px | 1280w (110KB) | **640w** (35KB) | -75KB/card |
| 1440 strip 347px | 1600w (156KB) | **640w** (35KB) | -120KB/card |
| 1440 DocCard 339px | 640w | **320w** (lieve upscale 6%) | -55KB/card |
| 768 DocCard 220px | 640w | **320w** | -55KB/card |

Stima: ~700KB risparmiati sulla homepage al primo load su desktop 1280px DPR=1.

## Note

Il caso 1440 DPR=1 carica 320w per card da 339px → upscale di ~6%. Visivamente impercettibile, ma se vuoi precisione assoluta si può aggiungere un breakpoint `(max-width: 1280px) 320px, 360px` (lascio la decisione su questa PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)