### PR TITLE
feat(blog): card editoriali su indice, tag e autori del blog

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -90,10 +90,14 @@ const config: Config = {
           // people actually skim editorial-blog content). Keep this in
           // sync with READING_WPM in scripts/generate-blog-index.js so the
           // homepage strip and the post header show the same number.
-          readingTime: ({content, frontMatter, defaultReadingTime}) =>
+          readingTime: ({content, frontMatter, locale, defaultReadingTime}) =>
             frontMatter.hide_reading_time
               ? undefined
-              : defaultReadingTime({content, options: {wordsPerMinute: 350}}),
+              : defaultReadingTime({
+                  content,
+                  locale,
+                  options: {wordsPerMinute: 350},
+                }),
           feedOptions: {
             type: ['rss', 'atom'],
             xslt: true,

--- a/src/components/BlogCardGrid.tsx
+++ b/src/components/BlogCardGrid.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+import type {PropBlogPostContent} from '@docusaurus/plugin-content-blog';
+import OptimizedImage from './OptimizedImage';
+import styles from './LatestBlogPosts.module.css';
+
+// Single source of truth for the editorial blog card grid: the homepage
+// "Dal blog" strip (LatestBlogPosts) and the blog index / tag / author listing
+// pages all render through this component, so the cards look identical
+// everywhere. Both feeds normalise their data into BlogCardData first.
+
+export interface BlogCardData {
+  permalink: string;
+  title: string;
+  /** ISO date string (YYYY-MM-DD). */
+  date: string;
+  description?: string;
+  readingTime?: number;
+  authorName?: string;
+  image?: string;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('it-IT', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+function formatDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return dateFormatter.format(d);
+}
+
+/** Adapt the theme `items` array (blog list / tag / author pages) to cards. */
+export function blogItemsToCards(
+  items: readonly {readonly content: PropBlogPostContent}[],
+): BlogCardData[] {
+  return items.map(({content}) => {
+    const {metadata, frontMatter} = content;
+    return {
+      permalink: metadata.permalink,
+      title: metadata.title,
+      date: new Date(metadata.date).toISOString().slice(0, 10),
+      description: metadata.description,
+      readingTime: metadata.readingTime,
+      authorName: metadata.authors?.[0]?.name,
+      image: frontMatter.image as string | undefined,
+    };
+  });
+}
+
+function PostCard({
+  post,
+  titleAs,
+}: {
+  post: BlogCardData;
+  titleAs: 'h2' | 'h3';
+}): React.ReactElement {
+  return (
+    <Link to={post.permalink} className={styles.cardLink} aria-label={post.title}>
+      <article className={styles.card}>
+        {post.image && (
+          <div className={styles.imageWrapper}>
+            <OptimizedImage
+              src={post.image}
+              alt={post.title}
+              className={styles.image}
+              // Strip auto-fill minmax(300px, 1fr): card 340-450px
+              // (1 col su mobile, 2 col su tablet, 3-4 col su desktop).
+              sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 360px"
+            />
+          </div>
+        )}
+        <div className={styles.content}>
+          <div className={styles.eyebrow}>
+            <time dateTime={post.date}>{formatDate(post.date)}</time>
+            {post.readingTime != null && (
+              <span> · {Math.ceil(post.readingTime)} min</span>
+            )}
+            {post.authorName && (
+              <span className={styles.author}> · {post.authorName}</span>
+            )}
+          </div>
+          <Heading as={titleAs} className={styles.title}>{post.title}</Heading>
+          {post.description && <p className={styles.description}>{post.description}</p>}
+          <span className={styles.cta}>Leggi →</span>
+        </div>
+      </article>
+    </Link>
+  );
+}
+
+export default function BlogCardGrid({
+  posts = [],
+  titleAs = 'h2',
+}: {
+  posts?: BlogCardData[];
+  /** Heading level for the card title. Homepage uses h3 (under the section h2). */
+  titleAs?: 'h2' | 'h3';
+}): React.ReactElement {
+  return (
+    <div className={styles.grid}>
+      {posts.map((post) => (
+        <PostCard key={post.permalink} post={post} titleAs={titleAs} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/LatestBlogPosts.module.css
+++ b/src/components/LatestBlogPosts.module.css
@@ -100,21 +100,27 @@
 .eyebrow time { color: var(--pg-ink); }
 .author { color: var(--pg-ink-faint); }
 
-.title {
+/* Scoped under .card so the module controls the card typography in every
+   context. On the homepage the strip sits inside `.markdown`, whose
+   `.markdown h3` / `.markdown p` rules would otherwise win over a bare
+   `.title` / `.description` class and make the homepage cards differ from the
+   blog/tag/author listing cards (which render outside `.markdown`). The values
+   below match the homepage's effective look so nothing changes there. */
+.card .title {
   margin: 2px 0 4px;
   font-family: var(--pg-font-serif);
-  font-weight: 900;
-  letter-spacing: -0.01em;
-  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  font-size: 24px;
   line-height: 1.15;
   color: var(--pg-ink);
 }
 
-.description {
+.card .description {
   margin: 0;
   font-family: var(--pg-font-serif);
-  font-size: 15px;
-  line-height: 1.45;
+  font-size: 17px;
+  line-height: 1.65;
   color: var(--pg-ink-soft);
   flex: 1;
 }

--- a/src/components/LatestBlogPosts.tsx
+++ b/src/components/LatestBlogPosts.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
-import {BLOG_INDEX, type BlogIndexEntry} from '../data/blog-index';
-import OptimizedImage from './OptimizedImage';
+import {BLOG_INDEX} from '../data/blog-index';
+import BlogCardGrid, {type BlogCardData} from './BlogCardGrid';
 import styles from './LatestBlogPosts.module.css';
 
 interface LatestBlogPostsProps {
@@ -21,53 +21,6 @@ interface LatestBlogPostsProps {
   seeAllLabel?: string;
 }
 
-const dateFormatter = new Intl.DateTimeFormat('it-IT', {
-  day: 'numeric',
-  month: 'long',
-  year: 'numeric',
-  timeZone: 'UTC',
-});
-
-function formatDate(iso: string): string {
-  const d = new Date(`${iso}T00:00:00Z`);
-  if (Number.isNaN(d.getTime())) return iso;
-  return dateFormatter.format(d);
-}
-
-function PostCard({post}: {post: BlogIndexEntry}): React.ReactElement {
-  const author = post.authors[0];
-  return (
-    <Link to={post.permalink} className={styles.cardLink} aria-label={post.title}>
-      <article className={styles.card}>
-        {post.image && (
-          <div className={styles.imageWrapper}>
-            <OptimizedImage
-              src={post.image}
-              alt={post.title}
-              className={styles.image}
-              // Strip auto-fill minmax(300px, 1fr): card 340-450px
-              // (1 col su mobile, 2 col su tablet, 3-4 col su desktop).
-              sizes="(max-width: 480px) 100vw, (max-width: 1024px) 50vw, 360px"
-            />
-          </div>
-        )}
-        <div className={styles.content}>
-          <div className={styles.eyebrow}>
-            <time dateTime={post.date}>{formatDate(post.date)}</time>
-            {post.readingTime != null && (
-              <span> · {Math.ceil(post.readingTime)} min</span>
-            )}
-            {author && <span className={styles.author}> · {author.name}</span>}
-          </div>
-          <Heading as="h3" className={styles.title}>{post.title}</Heading>
-          {post.description && <p className={styles.description}>{post.description}</p>}
-          <span className={styles.cta}>Leggi →</span>
-        </div>
-      </article>
-    </Link>
-  );
-}
-
 export default function LatestBlogPosts({
   limit = 2,
   minPosts = 0,
@@ -75,7 +28,15 @@ export default function LatestBlogPosts({
   seeAllLabel = 'Tutti i post →',
 }: LatestBlogPostsProps): React.ReactElement | null {
   if (BLOG_INDEX.length < minPosts) return null;
-  const posts = BLOG_INDEX.slice(0, limit);
+  const posts: BlogCardData[] = BLOG_INDEX.slice(0, limit).map((p) => ({
+    permalink: p.permalink,
+    title: p.title,
+    date: p.date,
+    description: p.description ?? undefined,
+    readingTime: p.readingTime ?? undefined,
+    authorName: p.authors[0]?.name,
+    image: p.image ?? undefined,
+  }));
   if (posts.length === 0) return null;
   return (
     <section className={styles.wrapper}>
@@ -87,9 +48,7 @@ export default function LatestBlogPosts({
           )}
         </div>
       )}
-      <div className={styles.grid}>
-        {posts.map((p) => <PostCard key={p.slug} post={p} />)}
-      </div>
+      <BlogCardGrid posts={posts} titleAs="h3" />
     </section>
   );
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1383,112 +1383,34 @@ article > .theme-doc-markdown.markdown > p:first-of-type::first-letter,
   margin-bottom: 0.4em;
 }
 
-/* Inline article rows on list / tag-posts / author-posts pages
-   (no card chrome — match docusaurus.io/blog: full posts stacked,
-   separated by a hairline rule, same typography as the single post). */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article {
-  background: transparent;
-  border: 0;
-  padding: 0 0 56px;
-  margin: 0 0 56px;
-  border-bottom: 1px solid var(--pg-rule-soft);
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article:last-of-type {
-  border-bottom: 0;
-  margin-bottom: 0;
-  padding-bottom: 0;
-}
-/* Title size matches the single-post H1 so the two pages feel like one document. */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article > header h2 {
-  font-family: var(--pg-font-serif);
-  font-weight: 900;
-  letter-spacing: -0.015em;
-  font-size: clamp(36px, 5.5vw, 60px);
-  line-height: 1;
-  margin: 0 0 12px;
-  border-bottom: 0;
-  padding-bottom: 0;
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article > header h2 a {
-  color: var(--pg-ink);
-  text-decoration: none;
-  border-bottom: 0;
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article > header h2 a:hover {
-  color: var(--pg-red-ink);
-}
+/* The blog index, tag and author listings now render as editorial cards
+   (BlogCardGrid — same component as the homepage "Dal blog" strip), so the
+   old "inline article rows" chrome that used to style each `article` on these
+   pages has been removed. The card styling lives in LatestBlogPosts.module.css.
+   The rules below are scoped so they keep applying to the single-post page
+   (.blog-post-page), whose `article` still uses the default theme structure. */
 
-/* Date / reading time strip */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > header > div {
+/* Date / reading time strip (single post page) */
+.blog-post-page article > header > div {
   font-family: var(--pg-font-mono);
   font-size: 11.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--pg-ink-faint);
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > header > div time {
+.blog-post-page article > header > div time {
   color: var(--pg-ink);
 }
 
-/* Excerpt body on list-style pages */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page) article .markdown p {
-  font-family: var(--pg-font-serif);
-  font-size: 17px;
-  line-height: 1.6;
-  color: var(--pg-ink-soft);
-}
-
-/* Article footer (Read More + tags) */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > footer {
+/* Article footer (tags) on the single post page */
+.blog-post-page article > footer {
   border-top: 1px solid var(--pg-rule-soft);
   padding-top: 14px;
   margin-top: 18px;
 }
-/* "Leggi l'articolo completo →" CTA on list/tag/author pages.
-   Docusaurus renders this as a plain <a><b>label</b></a> in
-   .col.text--right (no .button class), so we target that path
-   directly. The arrow is a CSS pseudo so it can animate on hover
-   without bloating the translation string. */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
-    article > footer .col.text--right > a {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-  font-family: var(--pg-font-serif);
-  font-weight: 800;
-  font-size: 18px;
-  letter-spacing: -0.005em;
-  color: var(--pg-red);
-  text-decoration: none;
-  border-bottom: 0;
-  transition: color 0.15s ease;
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
-    article > footer .col.text--right > a > b {
-  font-weight: inherit;
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
-    article > footer .col.text--right > a::after {
-  content: '→';
-  font-weight: 700;
-  display: inline-block;
-  transition: transform 0.18s ease;
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
-    article > footer .col.text--right > a:hover {
-  color: var(--pg-red-ink);
-}
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page)
-    article > footer .col.text--right > a:hover::after {
-  transform: translateX(5px);
-}
 
-/* Tag chips inside an article */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article ul[class*='tags_'] {
+/* Tag chips inside an article (single post page) */
+.blog-post-page article ul[class*='tags_'] {
   list-style: none;
   padding: 0;
   margin: 12px 0 0;
@@ -1496,10 +1418,8 @@ article > .theme-doc-markdown.markdown > p:first-of-type::first-letter,
   flex-wrap: wrap;
   gap: 8px;
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article ul[class*='tags_'] li { margin: 0; }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article ul[class*='tags_'] a {
+.blog-post-page article ul[class*='tags_'] li { margin: 0; }
+.blog-post-page article ul[class*='tags_'] a {
   font-family: var(--pg-font-mono);
   font-size: 11px;
   letter-spacing: 0.1em;
@@ -1511,8 +1431,7 @@ article > .theme-doc-markdown.markdown > p:first-of-type::first-letter,
   border-radius: 999px;
   text-decoration: none;
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article ul[class*='tags_'] a:hover {
+.blog-post-page article ul[class*='tags_'] a:hover {
   background: var(--pg-yellow);
   color: var(--pg-ink);
 }
@@ -1530,22 +1449,19 @@ article > .theme-doc-markdown.markdown > p:first-of-type::first-letter,
 .blog-post-page nav.pagination-nav { margin-top: 32px; }
 .blog-list-page nav.pagination-nav { margin-top: 16px; }
 
-/* Author info row inside article header */
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > header .avatar { margin-top: 8px; }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > header .avatar__name {
+/* Author byline inside the single post article header */
+.blog-post-page article > header .avatar { margin-top: 8px; }
+.blog-post-page article > header .avatar__name {
   font-family: var(--pg-font-serif);
   font-weight: 800;
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page) article > header .avatar small {
+.blog-post-page article > header .avatar small {
   font-family: var(--pg-font-sans);
   font-size: 12px;
   color: var(--pg-ink-faint);
 }
-:is(.blog-list-page, .blog-tags-post-list-page, .blog-authors-posts-page,
-    .blog-post-page, .blog-authors-list-page) .avatar__photo {
+/* Author avatar photo on the author posts/list pages + single post byline */
+:is(.blog-authors-posts-page, .blog-authors-list-page, .blog-post-page) .avatar__photo {
   border: 2px solid var(--pg-ink);
   background: var(--pg-paper-2);
 }

--- a/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
+++ b/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
@@ -1,18 +1,81 @@
 import React, {type ReactNode} from 'react';
-import BlogAuthorsPostsPage from '@theme-original/Blog/Pages/BlogAuthorsPostsPage';
-import type BlogAuthorsPostsPageType from '@theme/Blog/Pages/BlogAuthorsPostsPage';
-import type {WrapperProps} from '@docusaurus/types';
+import clsx from 'clsx';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {
+  useBlogAuthorPageTitle,
+  BlogAuthorsListViewAllLabel,
+  BlogAuthorNoPostsLabel,
+} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import {useBlogMetadata} from '@docusaurus/plugin-content-blog/client';
+import BlogLayout from '@theme/BlogLayout';
+import BlogListPaginator from '@theme/BlogListPaginator';
+import SearchMetadata from '@theme/SearchMetadata';
+import type {Props} from '@theme/Blog/Pages/BlogAuthorsPostsPage';
+import Author from '@theme/Blog/Components/Author';
+import BlogCardGrid, {blogItemsToCards} from '@site/src/components/BlogCardGrid';
 import NoindexMeta from '@site/src/components/NoindexMeta';
 
-type Props = WrapperProps<typeof BlogAuthorsPostsPageType>;
+// Ejected (not wrapped): renders per-author listings as homepage-style cards
+// (BlogCardGrid) instead of the default BlogPostItems list. These thin utility
+// /blog/authors/<author>/ pages stay out of the search index (NoindexMeta).
 
-// Wrap (not eject): per-author /blog/authors/<author>/ listings are thin
-// utility pages — keep them out of the search index.
-export default function BlogAuthorsPostsPageWrapper(props: Props): ReactNode {
+function Metadata({author}: Props): ReactNode {
+  const title = useBlogAuthorPageTitle(author);
   return (
     <>
-      <NoindexMeta />
-      <BlogAuthorsPostsPage {...props} />
+      <PageMetadata title={title} />
+      <SearchMetadata tag="blog_authors_posts" />
     </>
+  );
+}
+
+function ViewAllAuthorsLink() {
+  const {authorsListPath} = useBlogMetadata();
+  return (
+    <Link href={authorsListPath}>
+      <BlogAuthorsListViewAllLabel />
+    </Link>
+  );
+}
+
+function Content({author, items, sidebar, listMetadata}: Props): ReactNode {
+  return (
+    <BlogLayout sidebar={sidebar}>
+      <header className="margin-bottom--xl">
+        <Author as="h1" author={author} />
+        {author.description && <p>{author.description}</p>}
+        <ViewAllAuthorsLink />
+      </header>
+      {items.length === 0 ? (
+        <p>
+          <BlogAuthorNoPostsLabel />
+        </p>
+      ) : (
+        <>
+          <hr />
+          <BlogCardGrid posts={blogItemsToCards(items)} />
+          <BlogListPaginator metadata={listMetadata} />
+        </>
+      )}
+    </BlogLayout>
+  );
+}
+
+export default function BlogAuthorsPostsPage(props: Props): ReactNode {
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogAuthorsPostsPage,
+      )}>
+      <NoindexMeta />
+      <Metadata {...props} />
+      <Content {...props} />
+    </HtmlClassNameProvider>
   );
 }

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -1,20 +1,64 @@
 import React, {type ReactNode} from 'react';
-import BlogListPage from '@theme-original/BlogListPage';
-import type BlogListPageType from '@theme/BlogListPage';
-import type {WrapperProps} from '@docusaurus/types';
+import clsx from 'clsx';
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import BlogLayout from '@theme/BlogLayout';
+import BlogListPaginator from '@theme/BlogListPaginator';
+import SearchMetadata from '@theme/SearchMetadata';
+import type {Props} from '@theme/BlogListPage';
+import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
+import BlogCardGrid, {blogItemsToCards} from '@site/src/components/BlogCardGrid';
 import NoindexMeta from '@site/src/components/NoindexMeta';
 
-type Props = WrapperProps<typeof BlogListPageType>;
+// Ejected (not wrapped): renders the blog index as homepage-style editorial
+// cards (BlogCardGrid) instead of the default full BlogPostItems list, while
+// keeping layout, metadata, structured data and pagination intact.
+// Paginated pages (/blog/page/2/ and beyond) are noindexed — page 1 (/blog/)
+// is the real, indexable blog home.
 
-// Wrap (not eject): noindex only the paginated blog index pages
-// (/blog/page/2/ and beyond). Page 1 (/blog/) is the real, indexable blog
-// home — `metadata.page` is 1 there — so we leave it untouched.
-export default function BlogListPageWrapper(props: Props): ReactNode {
-  const isPaginated = props.metadata.page > 1;
+function BlogListPageMetadata(props: Props): ReactNode {
+  const {metadata} = props;
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {blogDescription, blogTitle, permalink} = metadata;
+  const isBlogOnlyMode = permalink === '/';
+  const title = isBlogOnlyMode ? siteTitle : blogTitle;
   return (
     <>
-      {isPaginated && <NoindexMeta />}
-      <BlogListPage {...props} />
+      <PageMetadata title={title} description={blogDescription} />
+      <SearchMetadata tag="blog_posts_list" />
     </>
+  );
+}
+
+function BlogListPageContent(props: Props): ReactNode {
+  const {metadata, items, sidebar} = props;
+  return (
+    <BlogLayout sidebar={sidebar}>
+      <BlogCardGrid posts={blogItemsToCards(items)} />
+      <BlogListPaginator metadata={metadata} />
+    </BlogLayout>
+  );
+}
+
+export default function BlogListPage(props: Props): ReactNode {
+  const isPaginated = props.metadata.page > 1;
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogListPage,
+      )}>
+      {isPaginated && <NoindexMeta />}
+      <BlogListPageMetadata {...props} />
+      <BlogListPageStructuredData {...props} />
+      <BlogListPageContent {...props} />
+    </HtmlClassNameProvider>
   );
 }

--- a/src/theme/BlogTagsPostsPage/index.tsx
+++ b/src/theme/BlogTagsPostsPage/index.tsx
@@ -1,18 +1,73 @@
 import React, {type ReactNode} from 'react';
-import BlogTagsPostsPage from '@theme-original/BlogTagsPostsPage';
-import type BlogTagsPostsPageType from '@theme/BlogTagsPostsPage';
-import type {WrapperProps} from '@docusaurus/types';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import {
+  PageMetadata,
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {useBlogTagsPostsPageTitle} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import BlogLayout from '@theme/BlogLayout';
+import BlogListPaginator from '@theme/BlogListPaginator';
+import SearchMetadata from '@theme/SearchMetadata';
+import type {Props} from '@theme/BlogTagsPostsPage';
+import Unlisted from '@theme/ContentVisibility/Unlisted';
+import Heading from '@theme/Heading';
+import BlogCardGrid, {blogItemsToCards} from '@site/src/components/BlogCardGrid';
 import NoindexMeta from '@site/src/components/NoindexMeta';
 
-type Props = WrapperProps<typeof BlogTagsPostsPageType>;
+// Ejected (not wrapped): renders tag listings as homepage-style cards
+// (BlogCardGrid) instead of the default BlogPostItems list. These thin utility
+// /blog/tags/<tag>/ pages stay out of the search index (NoindexMeta).
 
-// Wrap (not eject): individual /blog/tags/<tag>/ pages (and their /page/N/
-// variants) are thin utility listings — keep them out of the search index.
-export default function BlogTagsPostsPageWrapper(props: Props): ReactNode {
+function BlogTagsPostsPageMetadata({tag}: Props): ReactNode {
+  const title = useBlogTagsPostsPageTitle(tag);
   return (
     <>
-      <NoindexMeta />
-      <BlogTagsPostsPage {...props} />
+      <PageMetadata title={title} description={tag.description} />
+      <SearchMetadata tag="blog_tags_posts" />
     </>
+  );
+}
+
+function BlogTagsPostsPageContent({
+  tag,
+  items,
+  sidebar,
+  listMetadata,
+}: Props): ReactNode {
+  const title = useBlogTagsPostsPageTitle(tag);
+  return (
+    <BlogLayout sidebar={sidebar}>
+      {tag.unlisted && <Unlisted />}
+      <header className="margin-bottom--xl">
+        <Heading as="h1">{title}</Heading>
+        {tag.description && <p>{tag.description}</p>}
+        <Link href={tag.allTagsPath}>
+          <Translate
+            id="theme.tags.tagsPageLink"
+            description="The label of the link targeting the tag list page">
+            View All Tags
+          </Translate>
+        </Link>
+      </header>
+      <BlogCardGrid posts={blogItemsToCards(items)} />
+      <BlogListPaginator metadata={listMetadata} />
+    </BlogLayout>
+  );
+}
+
+export default function BlogTagsPostsPage(props: Props): ReactNode {
+  return (
+    <HtmlClassNameProvider
+      className={clsx(
+        ThemeClassNames.wrapper.blogPages,
+        ThemeClassNames.page.blogTagPostListPage,
+      )}>
+      <NoindexMeta />
+      <BlogTagsPostsPageMetadata {...props} />
+      <BlogTagsPostsPageContent {...props} />
+    </HtmlClassNameProvider>
   );
 }


### PR DESCRIPTION
## Cosa

Indice blog (`/blog`), pagine tag (`/blog/tags/*`) e pagine autore (`/blog/authors/*`) ora renderizzano le stesse **card editoriali** della homepage ("Dal blog"), invece della lista di post di default.

## Come

- **Nuovo `BlogCardGrid`** — unica fonte per griglia + card del blog. Usato sia dalla strip homepage (`LatestBlogPosts`) sia dai tre swizzle di listing. `LatestBlogPosts` è stato estratto: mantiene solo wrapper/heading/CTA `minPosts` e delega la griglia a `BlogCardGrid` via la shape normalizzata `BlogCardData`; le pagine del theme adattano gli `items` con l'helper `blogItemsToCards()`. La card è quindi scritta **una sola volta**.
- **Eject dei tre swizzle** (`BlogListPage`, `BlogTagsPostsPage`, `Blog/Pages/BlogAuthorsPostsPage`): renderizzano `BlogCardGrid` al posto di `BlogPostItems`, preservando layout, paginatore, metadata, structured data e i `noindex` già presenti (pagine paginate / tag / autori).
- **CSS** (`custom.css`): rimosso il vecchio chrome "inline article rows" che, con specificità maggiore di `.card`, rendeva le card trasparenti e senza bordo; le regole residue (date strip, footer, tag chip, avatar) sono state ristrette a `.blog-post-page` dove servono ancora. Titolo e descrizione della card sono stati scopati sotto `.card` così il modulo vince sul cascade `.markdown` e le card risultano **identiche in ogni contesto** (homepage inclusa, che resta invariata: titolo 24px / desc 17px).
- **fix(config)**: errore di typecheck preesistente — `readingTime` ora passa `locale` a `defaultReadingTime` (richiesto dalle nuove tipizzazioni del plugin blog).

## Verifica

- `npm run typecheck` pulito; `npm run build` completa la SSR senza errori.
- Su dev server pulito (console senza errori): homepage card invariata; `/blog` 10 card, `/blog/authors/jeko` 3 card, `/blog/tags/cucina` 7 card — tutte bianche, bordo 2px, titolo 24px, header e `noindex` intatti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)